### PR TITLE
Update scrollX and scrollY values for html2canvas

### DIFF
--- a/public/components/visual_report/generate_report.ts
+++ b/public/components/visual_report/generate_report.ts
@@ -161,6 +161,8 @@ export const generateReport = async (id: string, forceDelay = 15000) => {
     footer
   );
   return html2canvas(document.body, {
+    scrollX: 0,
+    scrollY: 0,
     windowWidth: width,
     windowHeight: height,
     width,


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
Force scrollX and scrollY to be zero instead of actual values, otherwise if user scrolls down or right, the image will have a blank margin on top or left

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
