### PR TITLE
Support new notebooks URL

### DIFF
--- a/server/utils/__tests__/validationHelper.test.ts
+++ b/server/utils/__tests__/validationHelper.test.ts
@@ -95,6 +95,31 @@ const createReportDefinitionNotebookInput: ReportDefinitionSchemaType = {
   },
 }
 
+const createReportDefinitionNotebookPostNavBarInput: ReportDefinitionSchemaType = {
+  report_params: {
+    report_name: 'test notebooks report',
+    report_source: REPORT_TYPE.notebook,
+    description: 'Hi this is your Notebook on demand',
+    core_params: {
+      base_url: `/app/observability-notebooks#/${SAMPLE_SAVED_OBJECT_ID}`,
+      window_width: 1300,
+      window_height: 900,
+      report_format: FORMAT.pdf,
+      time_duration: 'PT5M',
+      origin: 'http://localhost:5601',
+    },
+  },
+  delivery: {
+    configIds: [],
+    title: 'title',
+    textDescription: 'text description',
+    htmlDescription: 'html description'
+  },
+  trigger: {
+    trigger_type: TRIGGER_TYPE.onDemand,
+  },
+}
+
 describe('test input validation', () => {
   test('create report with correct saved object id', async () => {
     const savedObjectIds = [`dashboard:${SAMPLE_SAVED_OBJECT_ID}`];
@@ -139,6 +164,16 @@ describe('test input validation', () => {
     const report = await validateReportDefinition(
       client,
       createReportDefinitionNotebookInput
+    );
+    expect(report).toBeDefined();
+  });
+
+  test('create notebook report definition with notebook base url format', async () => {
+    const savedObjectIds = [`notebook:${SAMPLE_SAVED_OBJECT_ID}`];
+    const client = mockOpenSearchClient(savedObjectIds);
+    const report = await validateReportDefinition(
+      client,
+      createReportDefinitionNotebookPostNavBarInput
     );
     expect(report).toBeDefined();
   });

--- a/server/utils/validationHelper.ts
+++ b/server/utils/validationHelper.ts
@@ -22,7 +22,7 @@ export const isValidRelativeUrl = (relativeUrl: string) => {
   ) {
     normalizedRelativeUrl = path.posix.normalize(relativeUrl);
   }
-  
+
   // check pattern
   // ODFE pattern: /app/dashboards#/view/7adfa750-4c81-11e8-b3d7-01146121b73d?_g
   // AES pattern: /_plugin/kibana/app/dashboards#/view/7adfa750-4c81-11e8-b3d7-01146121b73d?_g
@@ -37,7 +37,7 @@ export const isValidRelativeUrl = (relativeUrl: string) => {
 export const regexDuration = /^(-?)P(?=\d|T\d)(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)([DW]))?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?)?$/;
 export const regexEmailAddress = /\S+@\S+\.\S+/;
 export const regexReportName = /^[\w\-\s\(\)\[\]\,\_\-+]+$/;
-export const regexRelativeUrl = /^\/(_plugin\/kibana\/|_dashboards\/)?app\/(dashboards|visualize|discover|observability-dashboards|notebooks-dashboards\?view=output_only(&security_tenant=.+)?)(\?security_tenant=.+)?#\/(notebooks\/|view\/|edit\/)?[^\/]+$/;
+export const regexRelativeUrl = /^\/(_plugin\/kibana\/|_dashboards\/)?app\/(dashboards|visualize|discover|observability-dashboards|observability-notebooks|notebooks-dashboards\?view=output_only(&security_tenant=.+)?)(\?security_tenant=.+)?#\/(notebooks\/|view\/|edit\/)?[^\/]+$/;
 
 export const validateReport = async (
   client: ILegacyScopedClusterClient,
@@ -122,7 +122,7 @@ const validateSavedObject = async (
       index: '.kibana',
       id: savedObjectId,
     };
-    exist = await client.callAsCurrentUser('exists', params);  
+    exist = await client.callAsCurrentUser('exists', params);
   }
   if (!exist) {
     throw Error(`saved object with id ${savedObjectId} does not exist`);


### PR DESCRIPTION
### Description
Notebooks after nav bar change has a new URL `observability-notebooks`, allow it in validation

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
