### PR TITLE
Update breadcrumb title of isDashboardNavMenu

### DIFF
--- a/public/components/context_menu/context_menu.js
+++ b/public/components/context_menu/context_menu.js
@@ -264,7 +264,7 @@ const isDiscoverNavMenu = (navMenu) => {
 const isDashboardNavMenu = (navMenu) => {
   return (
     (navMenu[0].children.length === 4 || navMenu[0].children.length === 6) &&
-    $('[data-test-subj="breadcrumb first"]').prop('title') === 'Dashboard'
+    $('[data-test-subj="breadcrumb first"]').prop('title') === 'Dashboards'
   );
 };
 


### PR DESCRIPTION
### Description
https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4453

Modified the breadcrumbs from the dashboard plugin, to be consistent with the actual name of the application.

We should consider not hard checking the name of the breadcrumb but really hooking into the navigation
plugin that provides the ability to do what this
logic is doing without being hardcoded.

This is related to but does not resolve:
https://github.com/opensearch-project/dashboards-reporting/issues/118

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
