### PR TITLE
[CI/CD] Add single version flag during bootstrap to fix version conflicts

### DIFF
--- a/.github/workflows/cypress-e2e-reporting-test.yml
+++ b/.github/workflows/cypress-e2e-reporting-test.yml
@@ -117,7 +117,7 @@ jobs:
 
       - name: Boodstrap Opensearch Dashboards
         run: |
-          yarn osd bootstrap
+          yarn osd bootstrap --single-version=loose
         working-directory: OpenSearch-Dashboards
 
       - name: Run Opensearch Dashboards with Dashboards Reporting Plugin Installed

--- a/.github/workflows/ftr-e2e-reporting-test.yml
+++ b/.github/workflows/ftr-e2e-reporting-test.yml
@@ -117,7 +117,7 @@ jobs:
 
       - name: Boodstrap Opensearch Dashboards
         run: |
-          yarn osd bootstrap
+          yarn osd bootstrap --single-version=loose
         working-directory: OpenSearch-Dashboards
 
       - name: Run Opensearch Dashboards with Dashboards Reporting Plugin Installed

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Bootstrap the plugin
         working-directory: OpenSearch-Dashboards/plugins/${{ env.PLUGIN_NAME }}
-        run: yarn osd bootstrap
+        run: yarn osd bootstrap --single-version=loose
 
       - name: Get list of changed files using GitHub Action
         uses: lots0logs/gh-action-get-changed-files@2.2.2


### PR DESCRIPTION
### Description
On behalf of the change in dashboards core: https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5675. We need to add `--single-version=loose` flag during the bootstrap step in our CI to manipulate the behavior of single-version validation. 

### Issues Resolved
* Resolve the CI failure: https://github.com/opensearch-project/dashboards-observability/actions/runs/7964135017/job/21741091909?pr=1447#step:16:231

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
