### PR TITLE
Fix url parsing

### DIFF
--- a/public/components/context_menu/context_menu.js
+++ b/public/components/context_menu/context_menu.js
@@ -238,6 +238,7 @@ $(function () {
 
 /* generate a report if flagged in URL params */
 const checkURLParams = async () => {
+  if (!location.href.includes('#')) return;
   const [hash, query] = location.href.split('#')[1].split('?');
   const params = new URLSearchParams(query);
   const id = params.get(GENERATE_REPORT_PARAM);


### PR DESCRIPTION
### Description
Check if URL has `#` before split

### Issues Resolved
https://github.com/opensearch-project/dashboards-reporting/issues/281

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
