### PR TITLE
Bump path-to-regexp to 1.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "debug": "^4.3.4",
     "browserify-sign": "^4.2.2",
     "braces": "^3.0.3",
-    "micromatch": "^4.0.8"
+    "micromatch": "^4.0.8",
+    "path-to-regexp": "^1.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "debug": "^4.3.4",
     "browserify-sign": "^4.2.2",
     "braces": "^3.0.3",
-    "micromatch": "^4.0.8",
-    "path-to-regexp": "^1.9.0"
+    "micromatch": "^4.0.8"
   }
 }

--- a/release-notes/opensearch-dashboards-reporting.release-notes-2.17.0.0.md
+++ b/release-notes/opensearch-dashboards-reporting.release-notes-2.17.0.0.md
@@ -10,3 +10,4 @@ Compatible with OpenSearch and OpenSearch Dashboards Version 2.17.0
 ### Bug Fixes
 * [Bugfix] Update UI and handle new navigation ([#416](https://github.com/opensearch-project/dashboards-reporting/pull/416))
 * [Bug] Remove unused import  ([#419](https://github.com/opensearch-project/dashboards-reporting/pull/419))
+* Bump path-to-regexp to 1.9.0 ([#432](https://github.com/opensearch-project/dashboards-reporting/pull/432))

--- a/yarn.lock
+++ b/yarn.lock
@@ -4937,10 +4937,10 @@ path-parse@^1.0.7:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
-path-to-regexp@^1.7.0, path-to-regexp@^1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
-  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
+path-to-regexp@^1.7.0, path-to-regexp@^1.8.0, path-to-regexp@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.9.0.tgz#5dc0753acbf8521ca2e0f137b4578b917b10cf24"
+  integrity sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==
   dependencies:
     isarray "0.0.1"
 


### PR DESCRIPTION
### Description
Bump path-to-regexp to 1.9.0

### Issues Resolved
Resolves CVE: https://github.com/advisories/GHSA-9wv6-86v2-598j

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
