### PR TITLE
[BUG]Csv report generation had missing nested Fields

### DIFF
--- a/server/routes/utils/__tests__/savedSearchReportHelper.test.ts
+++ b/server/routes/utils/__tests__/savedSearchReportHelper.test.ts
@@ -909,7 +909,9 @@ describe('test create saved search report', () => {
           'geoip.location': { lon: -0.1, lat: 51.5 },
           customer_birth_date: '2023-04-26T04:34:32Z',
           order_date: '2023-04-26T04:34:32Z',
-          products: { created_on: '2023-04-26T04:34:32Z' },
+          products: [
+            { created_on: '2023-04-26T04:34:32Z' }
+          ],
         },
         {
           customer_birth_date: '2023-04-26T04:34:32Z',
@@ -924,7 +926,9 @@ describe('test create saved search report', () => {
           'geoip.location': { lon: -74, lat: 40.8 },
           customer_birth_date: '2023-04-26T04:34:32Z',
           order_date: '2023-04-26T04:34:32Z',
-          products: { created_on: '2023-04-26T04:34:32Z' },
+          products: [
+            { created_on: '2023-04-26T04:34:32Z' }
+          ],
         },
         {
           customer_birth_date: '2023-04-26T04:34:32Z',
@@ -933,10 +937,12 @@ describe('test create saved search report', () => {
         }
       ),
     ];
+    
     const client = mockOpenSearchClient(
       hits,
       '"geoip.country_iso_code", "geoip.city_name", "geoip.location"'
     );
+    
     const { dataUrl } = await createSavedSearchReport(
       input,
       client,
@@ -947,13 +953,15 @@ describe('test create saved search report', () => {
       mockLogger,
       mockTimezone
     );
-
+    
+    console.log(dataUrl, 'here');
+    
     expect(dataUrl).toEqual(
-      'geoip\\.country_iso_code,geoip\\.location\\.lon,geoip\\.location\\.lat,geoip\\.city_name\n' +
-        'GB,-0.1,51.5, \n' +
-        'US,-74,40.8,New York'
-    );
-  }, 20000);
+      'geoip\\.country_iso_code,products\\.created_on,geoip\\.location\\.lon,geoip\\.location\\.lat,geoip\\.city_name\n' +
+      'GB,"[""2023-04-26T04:34:32Z""]",-0.1,51.5, \n' +
+      'US,"[""2023-04-26T04:34:32Z""]",-74,40.8,New York'
+    );    
+  }, 20000);  
 
   test('create report by sanitizing data set for Excel', async () => {
     const hits = [

--- a/server/routes/utils/__tests__/savedSearchReportHelper.test.ts
+++ b/server/routes/utils/__tests__/savedSearchReportHelper.test.ts
@@ -1507,17 +1507,17 @@ test('create report for deeply nested inventory data set with escaped field name
           categories: {
             subcategories: [
               {
-                items: [{ price: 100 }, { price: 200 }]
+                items: [{ price: 100 }, { price: 200 }],
               },
               {
-                items: [{ price: 300 }, { price: 400 }]
-              }
-            ]
-          }
-        }
+                items: [{ price: 300 }, { price: 400 }],
+              },
+            ],
+          },
+        },
       },
       {
-        'inventory.categories.subcategories.items': `[[{"price":100},{"price":200}],[{"price":300},{"price":400}]]`
+        'inventory.categories.subcategories.items': `[[{"price":100},{"price":200}],[{"price":300},{"price":400}]]`,
       }
     ),
     hit(
@@ -1526,17 +1526,17 @@ test('create report for deeply nested inventory data set with escaped field name
           categories: {
             subcategories: [
               {
-                items: [{ price: 500 }, { price: 600 }]
+                items: [{ price: 500 }, { price: 600 }],
               },
               {
-                items: [{ price: 700 }, { price: 800 }]
-              }
-            ]
-          }
-        }
+                items: [{ price: 700 }, { price: 800 }],
+              },
+            ],
+          },
+        },
       },
       {
-        'inventory.categories.subcategories.items': `[[{"price":500},{"price":600}],[{"price":700},{"price":800}]]`
+        'inventory.categories.subcategories.items': `[[{"price":500},{"price":600}],[{"price":700},{"price":800}]]`,
       }
     ),
     hit(
@@ -1545,16 +1545,16 @@ test('create report for deeply nested inventory data set with escaped field name
           categories: {
             subcategories: [
               {
-                items: [{ price: 900 }]
-              }
-            ]
-          }
-        }
+                items: [{ price: 900 }],
+              },
+            ],
+          },
+        },
       },
       {
-        'inventory.categories.subcategories.items': `[[{"price":900}]]`
+        'inventory.categories.subcategories.items': `[[{"price":900}]]`,
       }
-    )
+    ),
   ];
 
   const client = mockOpenSearchClient(hits);

--- a/server/routes/utils/__tests__/savedSearchReportHelper.test.ts
+++ b/server/routes/utils/__tests__/savedSearchReportHelper.test.ts
@@ -937,12 +937,10 @@ describe('test create saved search report', () => {
         }
       ),
     ];
-    
     const client = mockOpenSearchClient(
       hits,
       '"geoip.country_iso_code", "geoip.city_name", "geoip.location"'
     );
-    
     const { dataUrl } = await createSavedSearchReport(
       input,
       client,

--- a/server/routes/utils/__tests__/savedSearchReportHelper.test.ts
+++ b/server/routes/utils/__tests__/savedSearchReportHelper.test.ts
@@ -60,7 +60,10 @@ describe('test create saved search report', () => {
   test('create report with expected file name', async () => {
     const hits: Array<{ _source: any }> = [];
     const client = mockOpenSearchClient(hits);
-    const { timeCreated: _timeCreated, fileName } = await createSavedSearchReport(
+    const {
+      timeCreated: _timeCreated,
+      fileName,
+    } = await createSavedSearchReport(
       input,
       client,
       mockDateFormat,
@@ -1493,8 +1496,10 @@ function mockOpenSearchClient(
           };
         case 'clearScroll':
           return null;
-          default:
-            throw new Error(`Fail due to unexpected function call on client: ${endpoint}`);
+        default:
+          throw new Error(
+            `Fail due to unexpected function call on client: ${endpoint}`
+          );
       }
     });
   return client;

--- a/server/routes/utils/__tests__/savedSearchReportHelper.test.ts
+++ b/server/routes/utils/__tests__/savedSearchReportHelper.test.ts
@@ -909,9 +909,7 @@ describe('test create saved search report', () => {
           'geoip.location': { lon: -0.1, lat: 51.5 },
           customer_birth_date: '2023-04-26T04:34:32Z',
           order_date: '2023-04-26T04:34:32Z',
-          products: [
-            { created_on: '2023-04-26T04:34:32Z' }
-          ],
+          products: [{ created_on: '2023-04-26T04:34:32Z' }],
         },
         {
           customer_birth_date: '2023-04-26T04:34:32Z',
@@ -926,9 +924,7 @@ describe('test create saved search report', () => {
           'geoip.location': { lon: -74, lat: 40.8 },
           customer_birth_date: '2023-04-26T04:34:32Z',
           order_date: '2023-04-26T04:34:32Z',
-          products: [
-            { created_on: '2023-04-26T04:34:32Z' }
-          ],
+          products: [{ created_on: '2023-04-26T04:34:32Z' }],
         },
         {
           customer_birth_date: '2023-04-26T04:34:32Z',
@@ -951,15 +947,12 @@ describe('test create saved search report', () => {
       mockLogger,
       mockTimezone
     );
-    
-    console.log(dataUrl, 'here');
-    
     expect(dataUrl).toEqual(
       'geoip\\.country_iso_code,products\\.created_on,geoip\\.location\\.lon,geoip\\.location\\.lat,geoip\\.city_name\n' +
-      'GB,"[""2023-04-26T04:34:32Z""]",-0.1,51.5, \n' +
-      'US,"[""2023-04-26T04:34:32Z""]",-74,40.8,New York'
-    );    
-  }, 20000);  
+        'GB,"[""2023-04-26T04:34:32Z""]",-0.1,51.5, \n' +
+        'US,"[""2023-04-26T04:34:32Z""]",-74,40.8,New York'
+    );
+  }, 20000);
 
   test('create report by sanitizing data set for Excel', async () => {
     const hits = [
@@ -1363,7 +1356,7 @@ test('create report with Etc/GMT-2 Timezone', async () => {
     true,
     undefined,
     mockLogger,
-    "Etc/GMT-2"
+    'Etc/GMT-2'
   );
 
   expect(dataUrl).toEqual(

--- a/server/routes/utils/__tests__/savedSearchReportHelper.test.ts
+++ b/server/routes/utils/__tests__/savedSearchReportHelper.test.ts
@@ -60,7 +60,7 @@ describe('test create saved search report', () => {
   test('create report with expected file name', async () => {
     const hits: Array<{ _source: any }> = [];
     const client = mockOpenSearchClient(hits);
-    const { timeCreated, fileName } = await createSavedSearchReport(
+    const { timeCreated: _timeCreated, fileName } = await createSavedSearchReport(
       input,
       client,
       mockDateFormat,
@@ -1212,7 +1212,7 @@ test('create report for data set contains null field value', async () => {
 
 test('create report for data set with metadata fields', async () => {
   const metadataFields = { _index: 'nameofindex', _id: 'someid' };
-  let hits = [
+  const hits = [
     hit(
       {
         category: 'c1',
@@ -1493,8 +1493,8 @@ function mockOpenSearchClient(
           };
         case 'clearScroll':
           return null;
-        default:
-          fail('Fail due to unexpected function call on client', endpoint);
+          default:
+            throw new Error(`Fail due to unexpected function call on client: ${endpoint}`);
       }
     });
   return client;
@@ -1572,9 +1572,9 @@ function mockIndexSettings() {
   `);
 }
 
-function hit(source_kv: any, fields_kv = {}) {
+function hit(sourceKv: any, fieldsKv = {}) {
   return {
-    _source: source_kv,
-    fields: fields_kv,
+    _source: sourceKv,
+    fields: fieldsKv,
   };
 }

--- a/server/routes/utils/dataReportHelpers.ts
+++ b/server/routes/utils/dataReportHelpers.ts
@@ -304,18 +304,15 @@ function traverse(data: any, keys: string[], result: { [key: string]: any } = {}
   keys.forEach((key) => {
     const value = _.get(data, key, undefined);
     
-    // If the key exists, directly assign the value to the result
     if (value !== undefined) {
       result[key] = value;
     } else {
-      // If the key doesn't exist directly, check for any partial matches in the flattened data
       Object.keys(data)
         .filter((sourceKey) => sourceKey.startsWith(key + '.'))
         .forEach((sourceKey) => {
           result[sourceKey] = data[sourceKey];
         });
       
-      // Check for arrays and flatten their contents into appropriate result keys
       Object.keys(data).forEach((dataKey) => {
         const arrayValue = data[dataKey];
         
@@ -341,7 +338,6 @@ function traverse(data: any, keys: string[], result: { [key: string]: any } = {}
       });
     }
   });
-  console.log(result);
   return result;
 }
 

--- a/server/routes/utils/dataReportHelpers.ts
+++ b/server/routes/utils/dataReportHelpers.ts
@@ -307,6 +307,31 @@ function traverse(data, keys, result = {}) {
       Object.keys(data)
         .filter((sourceKey) => sourceKey.startsWith(key + '.'))
         .forEach((sourceKey) => (result[sourceKey] = data[sourceKey]));
+      Object.keys(data).forEach((key) => {
+        const value = data[key];
+      
+        if (Array.isArray(value)) {
+          const flattenedValues = {};
+      
+          value.forEach((item) => {
+            Object.keys(item).forEach((subKey) => {
+              console.log(key, subKey);
+              const newKey = `${key}.${subKey}`;
+              if (!flattenedValues[newKey]) {
+                flattenedValues[newKey] = [];
+              }
+              flattenedValues[newKey].push(item[subKey]);
+            });
+          });
+      
+          // Add flattened values to the result object, ensuring no duplicates
+          Object.keys(flattenedValues).forEach((newKey) => {
+            result[newKey] = flattenedValues[newKey];
+          });
+        } else {
+          result[key] = value;
+        }
+      });
     }
   });
   return result;

--- a/server/routes/utils/dataReportHelpers.ts
+++ b/server/routes/utils/dataReportHelpers.ts
@@ -302,22 +302,18 @@ function traverse(data: any, keys: string[], result: { [key: string]: any } = {}
 
   keys.forEach((key) => {
     const value = _.get(data, key, undefined);
-    
+
     if (value !== undefined) {
       result[key] = value;
     } else {
-      Object.keys(data)
-        .filter((sourceKey) => sourceKey.startsWith(key + '.'))
-        .forEach((sourceKey) => {
-          result[sourceKey] = data[sourceKey];
-        });
-      
-      Object.keys(data).forEach((dataKey) => {
-        const arrayValue = data[dataKey];
-        
-        if (Array.isArray(arrayValue)) {
-          const flattenedValues: { [key: string]: any[] } = {};
+      const flattenedValues: { [key: string]: any[] } = {};
 
+      Object.keys(data).forEach((dataKey) => {
+        if (dataKey.startsWith(key + '.')) {
+          result[dataKey] = data[dataKey];
+        }
+        const arrayValue = data[dataKey];
+        if (Array.isArray(arrayValue)) {
           arrayValue.forEach((item) => {
             if (typeof item === 'object' && item !== null) {
               Object.keys(item).forEach((subKey) => {
@@ -329,14 +325,15 @@ function traverse(data: any, keys: string[], result: { [key: string]: any } = {}
               });
             }
           });
-      
-          Object.keys(flattenedValues).forEach((newKey) => {
-            result[newKey] = flattenedValues[newKey];
-          });
         }
+      });
+
+      Object.keys(flattenedValues).forEach((newKey) => {
+        result[newKey] = flattenedValues[newKey];
       });
     }
   });
+
   return result;
 }
 

--- a/server/routes/utils/dataReportHelpers.ts
+++ b/server/routes/utils/dataReportHelpers.ts
@@ -315,7 +315,6 @@ function traverse(data, keys, result = {}) {
       
           value.forEach((item) => {
             Object.keys(item).forEach((subKey) => {
-              console.log(key, subKey);
               const newKey = `${key}.${subKey}`;
               if (!flattenedValues[newKey]) {
                 flattenedValues[newKey] = [];

--- a/server/routes/utils/dataReportHelpers.ts
+++ b/server/routes/utils/dataReportHelpers.ts
@@ -235,20 +235,19 @@ export const convertToCSV = async (dataset, csvSeparator) => {
   return convertedData;
 };
 
-function flattenHits(hits, result = {}, prefix = '') {
-  for (const [key, value] of Object.entries(hits)) {
-    if (!hits.hasOwnProperty(key)) continue;
+function flattenHits(hits: any, result: { [key: string]: any } = {}, prefix = '') {
+  Object.entries(hits).forEach(([key, value]) => {
     if (
-      value != null &&
+      value !== null &&
       typeof value === 'object' &&
       !Array.isArray(value) &&
       Object.keys(value).length > 0
     ) {
-      flattenHits(value, result, prefix + key + '.');
+      flattenHits(value, result, `${prefix}${key}.`);
     } else {
-      result[prefix.replace(/^_source\./, '') + key] = value;
+      result[`${prefix.replace(/^_source\./, '')}${key}`] = value;
     }
-  }
+  });
   return result;
 }
 

--- a/server/routes/utils/dataReportHelpers.ts
+++ b/server/routes/utils/dataReportHelpers.ts
@@ -297,42 +297,51 @@ export const convertToExcel = async (dataset: any) => {
 };
 
 //Return only the selected fields
-function traverse(data, keys, result = {}) {
+function traverse(data: any, keys: string[], result: { [key: string]: any } = {}) {
+  // Flatten the data if necessary (ensure all nested fields are at the top level)
   data = flattenHits(data);
-  const sourceKeys = Object.keys(data);
+
   keys.forEach((key) => {
     const value = _.get(data, key, undefined);
-    if (value !== undefined) result[key] = value;
-    else {
+    
+    // If the key exists, directly assign the value to the result
+    if (value !== undefined) {
+      result[key] = value;
+    } else {
+      // If the key doesn't exist directly, check for any partial matches in the flattened data
       Object.keys(data)
         .filter((sourceKey) => sourceKey.startsWith(key + '.'))
-        .forEach((sourceKey) => (result[sourceKey] = data[sourceKey]));
-      Object.keys(data).forEach((key) => {
-        const value = data[key];
+        .forEach((sourceKey) => {
+          result[sourceKey] = data[sourceKey];
+        });
       
-        if (Array.isArray(value)) {
-          const flattenedValues = {};
-      
-          value.forEach((item) => {
-            Object.keys(item).forEach((subKey) => {
-              const newKey = `${key}.${subKey}`;
-              if (!flattenedValues[newKey]) {
-                flattenedValues[newKey] = [];
-              }
-              flattenedValues[newKey].push(item[subKey]);
-            });
+      // Check for arrays and flatten their contents into appropriate result keys
+      Object.keys(data).forEach((dataKey) => {
+        const arrayValue = data[dataKey];
+        
+        if (Array.isArray(arrayValue)) {
+          const flattenedValues: { [key: string]: any[] } = {};
+
+          arrayValue.forEach((item) => {
+            if (typeof item === 'object' && item !== null) {
+              Object.keys(item).forEach((subKey) => {
+                const newKey = `${dataKey}.${subKey}`;
+                if (!flattenedValues[newKey]) {
+                  flattenedValues[newKey] = [];
+                }
+                flattenedValues[newKey].push(item[subKey]);
+              });
+            }
           });
       
-          // Add flattened values to the result object, ensuring no duplicates
           Object.keys(flattenedValues).forEach((newKey) => {
             result[newKey] = flattenedValues[newKey];
           });
-        } else {
-          result[key] = value;
         }
       });
     }
   });
+  console.log(result);
   return result;
 }
 


### PR DESCRIPTION
### Description
On generating a CSV report from a saved search in Dashboards, nestsed fields for the index pattern was not getting parsed in the picture below
![image](https://github.com/user-attachments/assets/a1e8332d-2cd5-495b-8df2-a14e16d3a9a6)

RCA:
the [code](https://github.com/opensearch-project/dashboards-reporting/blob/main/server/routes/utils/dataReportHelpers.ts#L306) piece handling the nested fields only checked if the fields had a key with a . in them, it was ignoring the fields which had an array of objects to be added to the CSV file, the fix handles the nested array objects which are needed as a part of the nested fields
The fix handles all nested fields which were getting truncated

![image](https://github.com/user-attachments/assets/b1f0a20a-bda9-427c-8de3-33a48e2424ea)

### Issues Resolved
https://github.com/opensearch-project/dashboards-reporting/issues/375

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
