### PR TITLE
[Bug]Support for date range in report generation

### DIFF
--- a/public/components/report_definitions/create/create_report_definition.tsx
+++ b/public/components/report_definitions/create/create_report_definition.tsx
@@ -90,7 +90,12 @@ export interface timeRangeParams {
   timeTo: Date;
 }
 
-export function CreateReport(props: { [x: string]: any; setBreadcrumbs?: any; httpClient?: any; chrome: any }) {
+export function CreateReport(props: {
+  [x: string]: any;
+  setBreadcrumbs?: any;
+  httpClient?: any;
+  chrome: any;
+}) {
   const { chrome } = props;
 
   let createReportDefinitionRequest: reportDefinitionParams = {
@@ -108,7 +113,7 @@ export function CreateReport(props: { [x: string]: any; setBreadcrumbs?: any; ht
       configIds: [],
       title: '',
       textDescription: '',
-      htmlDescription: ''
+      htmlDescription: '',
     },
     trigger: {
       trigger_type: '',
@@ -212,7 +217,7 @@ export function CreateReport(props: { [x: string]: any; setBreadcrumbs?: any; ht
     addInvalidTimeRangeToastHandler();
   };
 
-  const removeToast = (removedToast: { id: string; }) => {
+  const removeToast = (removedToast: { id: string }) => {
     setToasts(toasts.filter((toast: any) => toast.id !== removedToast.id));
   };
 
@@ -245,7 +250,7 @@ export function CreateReport(props: { [x: string]: any; setBreadcrumbs?: any; ht
       setShowTriggerIntervalNaNError,
       timeRange,
       setShowTimeRangeError,
-      setShowCronError,
+      setShowCronError
     ).then((response) => {
       error = response;
     });
@@ -261,16 +266,20 @@ export function CreateReport(props: { [x: string]: any; setBreadcrumbs?: any; ht
             'Content-Type': 'application/json',
           },
         })
-        .then(async (resp: { scheduler_response: { reportDefinitionId: string; }; }) => {
-          //TODO: consider handle the on demand report generation from server side instead
-          if (metadata.trigger.trigger_type === 'On demand') {
-            const reportDefinitionId =
-              resp.scheduler_response.reportDefinitionId;
-            generateReportFromDefinitionId(reportDefinitionId, httpClient);
+        .then(
+          async (resp: {
+            scheduler_response: { reportDefinitionId: string };
+          }) => {
+            //TODO: consider handle the on demand report generation from server side instead
+            if (metadata.trigger.trigger_type === 'On demand') {
+              const reportDefinitionId =
+                resp.scheduler_response.reportDefinitionId;
+              generateReportFromDefinitionId(reportDefinitionId, httpClient);
+            }
+            window.location.assign(`reports-dashboards#/create=success`);
           }
-          window.location.assign(`reports-dashboards#/create=success`);
-        })
-        .catch((error: {body: { statusCode: number; }; }) => {
+        )
+        .catch((error: { body: { statusCode: number } }) => {
           console.log('error in creating report definition: ' + error);
           if (error.body.statusCode === 403) {
             handleErrorOnCreateToast('permissions');
@@ -306,12 +315,16 @@ export function CreateReport(props: { [x: string]: any; setBreadcrumbs?: any; ht
       <EuiPageBody>
         <EuiTitle>
           <h1>
-            {!getNavGroupEnabled && i18n.translate('opensearch.reports.createReportDefinition.title', {
-              defaultMessage: 'Create report definition',
-            })}
+            {!getNavGroupEnabled &&
+              i18n.translate(
+                'opensearch.reports.createReportDefinition.title',
+                {
+                  defaultMessage: 'Create report definition',
+                }
+              )}
           </h1>
         </EuiTitle>
-        {!getNavGroupEnabled && <EuiSpacer size='s' />}
+        {!getNavGroupEnabled && <EuiSpacer size="s" />}
         <ReportSettings
           edit={false}
           editDefinitionId={''} // empty string since we are coming from create

--- a/public/components/report_definitions/create/create_report_definition.tsx
+++ b/public/components/report_definitions/create/create_report_definition.tsx
@@ -203,7 +203,7 @@ export function CreateReport(props: {
     setToasts(toasts.filter((toast: any) => toast.id !== removedToast.id));
   };
 
-  const NewTimeRange = {
+  const newTimeRange = {
     timeFrom: new Date(),
     timeTo: new Date(),
   };

--- a/public/components/report_definitions/create/create_report_definition.tsx
+++ b/public/components/report_definitions/create/create_report_definition.tsx
@@ -312,7 +312,7 @@ export function CreateReport(props: {
           editDefinitionId={''} // empty string since we are coming from create
           reportDefinitionRequest={createReportDefinitionRequest}
           httpClientProps={props.httpClient}
-          timeRange={NewTimeRange}
+          timeRange={newTimeRange}
           showSettingsReportNameError={showSettingsReportNameError}
           settingsReportNameErrorMessage={settingsReportNameErrorMessage}
           showSettingsReportSourceError={showSettingsReportSourceError}
@@ -341,7 +341,7 @@ export function CreateReport(props: {
               onClick={() =>
                 createNewReportDefinition(
                   createReportDefinitionRequest,
-                  NewTimeRange
+                  newTimeRange
                 )
               }
               id={'createNewReportDefinition'}

--- a/public/components/report_definitions/create/create_report_definition.tsx
+++ b/public/components/report_definitions/create/create_report_definition.tsx
@@ -23,35 +23,35 @@ import {
 } from '../../utils/utils';
 import { definitionInputValidation } from '../utils/utils';
 
-interface reportParamsType {
+interface ReportParamsType {
   report_name: string;
   report_source: string;
   description: string;
-  core_params: visualReportParams | dataReportParams;
+  core_params: VisualReportParams | DataReportParams;
 }
-interface visualReportParams {
+interface VisualReportParams {
   base_url: string;
   report_format: string;
   header: string;
   footer: string;
   time_duration: string;
-  timeRangeParams: timeRangeParams;
+  timeRangeParams: TimeRangeParams;
 }
 
-interface dataReportParams {
+interface DataReportParams {
   saved_search_id: number;
   base_url: string;
   report_format: string;
   time_duration: string;
-  timeRangeParams: timeRangeParams;
+  timeRangeParams: TimeRangeParams;
 }
-interface triggerType {
+interface TriggerType {
   trigger_type: string;
   trigger_params?: any;
 }
 
-interface deliveryType {
-  configIds: Array<string>;
+interface DeliveryType {
+  configIds: string[];
   title: string;
   textDescription: string;
   htmlDescription: string;
@@ -79,13 +79,13 @@ interface Cron {
   };
 }
 
-export interface reportDefinitionParams {
-  report_params: reportParamsType;
-  delivery: deliveryType;
-  trigger: triggerType;
+export interface ReportDefinitionParams {
+  report_params: ReportParamsType;
+  delivery: DeliveryType;
+  trigger: TriggerType;
 }
 
-export interface timeRangeParams {
+export interface TimeRangeParams {
   timeFrom: Date;
   timeTo: Date;
 }
@@ -98,7 +98,7 @@ export function CreateReport(props: {
 }) {
   const { chrome } = props;
 
-  let createReportDefinitionRequest: reportDefinitionParams = {
+  let createReportDefinitionRequest: ReportDefinitionParams = {
     report_params: {
       report_name: '',
       report_source: '',
@@ -199,36 +199,18 @@ export function CreateReport(props: {
     addErrorOnCreateToastHandler(errorType);
   };
 
-  const addInvalidTimeRangeToastHandler = () => {
-    const errorToast = {
-      title: i18n.translate(
-        'opensearch.reports.createReportDefinition.error.invalidTimeRange',
-        { defaultMessage: 'Invalid time range selected.' }
-      ),
-      color: 'danger',
-      iconType: 'alert',
-      id: 'timeRangeErrorToast',
-    };
-    // @ts-ignore
-    setToasts(toasts.concat(errorToast));
-  };
-
-  const handleInvalidTimeRangeToast = () => {
-    addInvalidTimeRangeToastHandler();
-  };
-
   const removeToast = (removedToast: { id: string }) => {
     setToasts(toasts.filter((toast: any) => toast.id !== removedToast.id));
   };
 
-  let timeRange = {
+  const NewTimeRange = {
     timeFrom: new Date(),
     timeTo: new Date(),
   };
 
   const createNewReportDefinition = async (
-    metadata: reportDefinitionParams,
-    timeRange: timeRangeParams
+    metadata: ReportDefinitionParams,
+    timeRange: TimeRangeParams
   ) => {
     const { httpClient } = props;
     //TODO: need better handle
@@ -329,8 +311,8 @@ export function CreateReport(props: {
           edit={false}
           editDefinitionId={''} // empty string since we are coming from create
           reportDefinitionRequest={createReportDefinitionRequest}
-          httpClientProps={props['httpClient']}
-          timeRange={timeRange}
+          httpClientProps={props.httpClient}
+          timeRange={NewTimeRange}
           showSettingsReportNameError={showSettingsReportNameError}
           settingsReportNameErrorMessage={settingsReportNameErrorMessage}
           showSettingsReportSourceError={showSettingsReportSourceError}
@@ -359,7 +341,7 @@ export function CreateReport(props: {
               onClick={() =>
                 createNewReportDefinition(
                   createReportDefinitionRequest,
-                  timeRange
+                  NewTimeRange
                 )
               }
               id={'createNewReportDefinition'}

--- a/public/components/report_definitions/create/create_report_definition.tsx
+++ b/public/components/report_definitions/create/create_report_definition.tsx
@@ -35,6 +35,7 @@ interface visualReportParams {
   header: string;
   footer: string;
   time_duration: string;
+  timeRangeParams: timeRangeParams;
 }
 
 interface dataReportParams {
@@ -42,6 +43,7 @@ interface dataReportParams {
   base_url: string;
   report_format: string;
   time_duration: string;
+  timeRangeParams: timeRangeParams;
 }
 interface triggerType {
   trigger_type: string;

--- a/public/components/report_definitions/delivery/delivery.tsx
+++ b/public/components/report_definitions/delivery/delivery.tsx
@@ -25,7 +25,7 @@ import {
   testMessageFailureMessage,
 } from './delivery_constants';
 import 'react-mde/lib/styles/css/react-mde-all.css';
-import { reportDefinitionParams } from '../create/create_report_definition';
+import { ReportDefinitionParams } from '../create/create_report_definition';
 import ReactMDE from 'react-mde';
 import { converter } from '../utils';
 import { getAvailableNotificationsChannels } from '../../main/main_utils';
@@ -41,7 +41,7 @@ export let includeDelivery = false;
 export type ReportDeliveryProps = {
   edit: boolean;
   editDefinitionId: string;
-  reportDefinitionRequest: reportDefinitionParams;
+  reportDefinitionRequest: ReportDefinitionParams;
   httpClientProps: any;
   showDeliveryChannelError: boolean;
   deliveryChannelError: string;

--- a/public/components/report_definitions/report_settings/report_settings.tsx
+++ b/public/components/report_definitions/report_settings/report_settings.tsx
@@ -35,8 +35,8 @@ import {
 import ReactMde from 'react-mde';
 import 'react-mde/lib/styles/css/react-mde-all.css';
 import {
-  reportDefinitionParams,
-  timeRangeParams,
+  ReportDefinitionParams,
+  TimeRangeParams,
 } from '../create/create_report_definition';
 import {
   parseInContextUrl,
@@ -59,9 +59,9 @@ import { ReportTrigger } from '../report_trigger';
 type ReportSettingProps = {
   edit: boolean;
   editDefinitionId: string;
-  reportDefinitionRequest: reportDefinitionParams;
+  reportDefinitionRequest: ReportDefinitionParams;
   httpClientProps: any;
-  timeRange: timeRangeParams;
+  timeRange: TimeRangeParams;
   showSettingsReportNameError: boolean;
   settingsReportNameErrorMessage: string;
   showSettingsReportSourceError: boolean;

--- a/public/components/report_definitions/report_trigger/report_trigger.tsx
+++ b/public/components/report_definitions/report_trigger/report_trigger.tsx
@@ -21,7 +21,7 @@ import {
   EuiCompressedFieldNumber,
 } from '@elastic/eui';
 import moment, { Moment } from 'moment';
-import { reportDefinitionParams } from '../create/create_report_definition';
+import { ReportDefinitionParams } from '../create/create_report_definition';
 import {
   SCHEDULE_RECURRING_OPTIONS,
   INTERVAL_TIME_PERIODS,
@@ -36,7 +36,7 @@ import { TimezoneSelect } from './timezone';
 type ReportTriggerProps = {
   edit: boolean;
   editDefinitionId: string;
-  reportDefinitionRequest: reportDefinitionParams;
+  reportDefinitionRequest: ReportDefinitionParams;
   httpClientProps: any;
   showTriggerIntervalNaNError: boolean;
   showCronError: boolean;

--- a/public/components/report_definitions/utils/utils.tsx
+++ b/public/components/report_definitions/utils/utils.tsx
@@ -60,9 +60,13 @@ export const definitionInputValidation = async (
 
   // if time range is invalid
   const nowDate = new Date(moment.now());
-  if (timeRange.timeFrom > timeRange.timeTo || timeRange.timeTo > nowDate) {
+  if (timeRange.timeFrom > timeRange.timeTo || timeRange.timeTo > nowDate) {  
     setShowTimeRangeError(true);
     error = true;
+  }
+  else{
+    metadata.report_params.core_params.timeFrom = timeRange.timeFrom;
+    metadata.report_params.core_params.timeTo = timeRange.timeTo;
   }
 
   // if cron based and cron input is invalid

--- a/server/model/backendModel.ts
+++ b/server/model/backendModel.ts
@@ -36,6 +36,8 @@ export type BackendReportDefinitionType = {
   format: {
     duration: string;
     fileFormat: BACKEND_REPORT_FORMAT;
+    timeFrom: string;
+    timeTo: string;
     limit?: number;
     header?: string;
     footer?: string;

--- a/server/model/index.ts
+++ b/server/model/index.ts
@@ -42,6 +42,20 @@ export const dataReportSchema = schema.object({
       }
     },
   }),
+  timeFrom: schema.string({
+    validate(value) {
+      if (isNaN(Date.parse(value))) {
+        return `invalid timeFrom: ${value}`;
+      }
+    },
+  }),
+  timeTo: schema.string({
+    validate(value) {
+      if (isNaN(Date.parse(value))) {
+        return `invalid timeTo: ${value}`;
+      }
+    },
+  }),
   report_format: schema.oneOf([schema.literal(FORMAT.csv), schema.literal(FORMAT.xlsx)]),
   limit: schema.number({ defaultValue: DEFAULT_MAX_SIZE, min: 0 }),
   excel: schema.boolean({ defaultValue: true }),
@@ -70,6 +84,20 @@ export const visualReportSchema = schema.object({
     validate(value) {
       if (!regexDuration.test(value)) {
         return `invalid time duration: ${value}`;
+      }
+    },
+  }),
+  timeFrom: schema.string({
+    validate(value) {
+      if (isNaN(Date.parse(value))) {
+        return `invalid timeFrom: ${value}`;
+      }
+    },
+  }),
+  timeTo: schema.string({
+    validate(value) {
+      if (isNaN(Date.parse(value))) {
+        return `invalid timeTo: ${value}`;
       }
     },
   }),

--- a/server/routes/utils/__tests__/savedSearchReportHelper.test.ts
+++ b/server/routes/utils/__tests__/savedSearchReportHelper.test.ts
@@ -29,6 +29,8 @@ const input = {
         limit: 10000,
         excel: true,
         origin: 'http://localhost:5601',
+        timeFrom : '2012-07-29T09:23:55.300Z',
+        timeTo: '2020-07-29T06:43:55.301Z',
       },
     },
     delivery: {

--- a/server/routes/utils/converters/__tests__/backendToUi.test.ts
+++ b/server/routes/utils/converters/__tests__/backendToUi.test.ts
@@ -40,6 +40,8 @@ const input: BackendReportInstanceType = {
         fileFormat: BACKEND_REPORT_FORMAT.pdf,
         header: '<p>test header</p>',
         footer: '<p>fake footer</p>',
+        timeFrom: "2020-11-11T09:52:00.000Z",
+        timeTo: "2020-11-11T10:22:00.000Z"
       },
       trigger: {
         triggerType: BACKEND_TRIGGER_TYPE.cronSchedule,
@@ -85,6 +87,8 @@ const output = {
         origin: 'http://localhost:5601',
         window_width: 1600,
         window_height: 800,
+        timeFrom: "2020-11-11T09:52:00.000Z",
+        timeTo: "2020-11-11T10:22:00.000Z"
       },
     },
     trigger: {

--- a/server/routes/utils/converters/backendToUi.ts
+++ b/server/routes/utils/converters/backendToUi.ts
@@ -110,7 +110,7 @@ export const backendToUiReportDefinition = (
       name,
       isEnabled,
       source: { type: sourceType, description, id: sourceId, origin },
-      format: { fileFormat, duration, header, footer, limit },
+      format: { fileFormat, duration, header, footer, limit, timeFrom: timeFrom, timeTo: timeTo },
       trigger: { triggerType, schedule },
       delivery,
     },
@@ -131,7 +131,9 @@ export const backendToUiReportDefinition = (
               fileFormat,
               duration,
               baseUrl,
-              origin
+              origin,
+              timeFrom,
+              timeTo,
             )
           : getVisualReportCoreParams(
               fileFormat,
@@ -139,7 +141,9 @@ export const backendToUiReportDefinition = (
               footer,
               duration,
               baseUrl,
-              origin
+              origin,
+              timeFrom,
+              timeTo,
             ),
     },
     trigger: getUiTriggerParams(
@@ -187,7 +191,9 @@ const getVisualReportCoreParams = (
   footer: string = '',
   duration: string,
   baseUrl: string,
-  origin: string
+  origin: string,
+  timeFrom: string,
+  timeTo: string
 ): VisualReportSchemaType => {
   let res: VisualReportSchemaType = {
     base_url: baseUrl,
@@ -196,6 +202,8 @@ const getVisualReportCoreParams = (
     footer: footer,
     time_duration: duration,
     origin: origin,
+    timeFrom: timeFrom,
+    timeTo: timeTo,
   };
   return res;
 };
@@ -234,7 +242,9 @@ const getDataReportCoreParams = (
   fileFormat: BACKEND_REPORT_FORMAT,
   duration: string,
   baseUrl: string,
-  origin: string
+  origin: string,
+  timeFrom: string,
+  timeTo: string
 ): DataReportSchemaType => {
   let res: DataReportSchemaType = {
     base_url: baseUrl,
@@ -243,6 +253,8 @@ const getDataReportCoreParams = (
     time_duration: duration,
     saved_search_id: sourceId,
     origin: origin,
+    timeFrom: timeFrom,
+    timeTo: timeTo,
   };
   return res;
 };

--- a/server/routes/utils/converters/uiToBackend.ts
+++ b/server/routes/utils/converters/uiToBackend.ts
@@ -46,6 +46,8 @@ export const uiToBackendReportDefinition = (
         footer,
         limit,
         origin,
+        timeFrom: timeFrom,
+        timeTo: timeTo,
       },
     },
     trigger,
@@ -67,6 +69,8 @@ export const uiToBackendReportDefinition = (
       ...(limit && { limit: limit }),
       ...(header && { header: header }),
       ...(footer && { footer: footer }),
+      ...(timeFrom && { timeFrom: timeFrom }),
+      ...(timeTo && { timeTo: timeTo }),
     },
     trigger: getBackendTrigger(trigger),
     ...(getBackendDelivery(delivery) && {

--- a/server/utils/__tests__/validationHelper.test.ts
+++ b/server/utils/__tests__/validationHelper.test.ts
@@ -29,6 +29,8 @@ const createReportDefinitionInput: ReportDefinitionSchemaType = {
       report_format: FORMAT.pdf,
       time_duration: 'PT5M',
       origin: 'http://localhost:5601',
+      timeFrom: '2012-07-29T09:23:55.300Z',
+      timeTo:'2020-07-29T06:43:55.301Z'
     },
   },
   delivery: {
@@ -61,6 +63,8 @@ const createReportDefinitionNotebookLegacyInput: ReportDefinitionSchemaType = {
       report_format: FORMAT.pdf,
       time_duration: 'PT5M',
       origin: 'http://localhost:5601',
+      timeFrom: '2012-07-29T09:23:55.300Z',
+      timeTo:'2020-07-29T06:43:55.301Z'
     },
   },
   delivery: {
@@ -86,6 +90,8 @@ const createReportDefinitionNotebookInput: ReportDefinitionSchemaType = {
       report_format: FORMAT.pdf,
       time_duration: 'PT5M',
       origin: 'http://localhost:5601',
+      timeFrom: '2012-07-29T09:23:55.300Z',
+      timeTo:'2020-07-29T06:43:55.301Z'
     },
   },
   delivery: {
@@ -111,6 +117,8 @@ const createReportDefinitionNotebookPostNavBarInput: ReportDefinitionSchemaType 
       report_format: FORMAT.pdf,
       time_duration: 'PT5M',
       origin: 'http://localhost:5601',
+      timeFrom: '2012-07-29T09:23:55.300Z',
+      timeTo:'2020-07-29T06:43:55.301Z'
     },
   },
   delivery: {


### PR DESCRIPTION
### Description
While generating reports the time picker which shows the time from and time to is not working
![image](https://github.com/user-attachments/assets/d21a21e4-5732-44b5-8768-ceae050fb4e4)
![image](https://github.com/user-attachments/assets/93032e11-20c9-4ea2-8f12-2b33db0d7fd6)
it auto selects the range as 'Now' and the duration specified, This happens to the edit functionality of the reports as well.

Fix after
https://github.com/user-attachments/assets/401ec030-7b92-4647-89e9-d77f240377e3

### Issues Resolved
https://github.com/opensearch-project/dashboards-reporting/issues/414

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
