### PR TITLE
[Bug] Updated the optional parameters for timefrom and timeto

### DIFF
--- a/server/model/index.ts
+++ b/server/model/index.ts
@@ -42,21 +42,28 @@ export const dataReportSchema = schema.object({
       }
     },
   }),
-  timeFrom: schema.maybe(schema.string({
-    validate(value) {
-      if (isNaN(Date.parse(value))) {
-        return `invalid timeFrom: ${value}`;
-      }
-    },
-  })),
-  timeTo: schema.maybe(schema.string({
-    validate(value) {
-      if (isNaN(Date.parse(value))) {
-        return `invalid timeTo: ${value}`;
-      }
-    },
-  })),
-  report_format: schema.oneOf([schema.literal(FORMAT.csv), schema.literal(FORMAT.xlsx)]),
+  timeFrom: schema.maybe(
+    schema.string({
+      validate(value) {
+        if (isNaN(Date.parse(value))) {
+          return `invalid timeFrom: ${value}`;
+        }
+      },
+    })
+  ),
+  timeTo: schema.maybe(
+    schema.string({
+      validate(value) {
+        if (isNaN(Date.parse(value))) {
+          return `invalid timeTo: ${value}`;
+        }
+      },
+    })
+  ),
+  report_format: schema.oneOf([
+    schema.literal(FORMAT.csv),
+    schema.literal(FORMAT.xlsx),
+  ]),
   limit: schema.number({ defaultValue: DEFAULT_MAX_SIZE, min: 0 }),
   excel: schema.boolean({ defaultValue: true }),
 });
@@ -87,20 +94,24 @@ export const visualReportSchema = schema.object({
       }
     },
   }),
-  timeFrom: schema.maybe(schema.string({
-    validate(value) {
-      if (isNaN(Date.parse(value))) {
-        return `invalid timeFrom: ${value}`;
-      }
-    },
-  })),
-  timeTo: schema.maybe(schema.string({
-    validate(value) {
-      if (isNaN(Date.parse(value))) {
-        return `invalid timeTo: ${value}`;
-      }
-    },
-  })),
+  timeFrom: schema.maybe(
+    schema.string({
+      validate(value) {
+        if (isNaN(Date.parse(value))) {
+          return `invalid timeFrom: ${value}`;
+        }
+      },
+    })
+  ),
+  timeTo: schema.maybe(
+    schema.string({
+      validate(value) {
+        if (isNaN(Date.parse(value))) {
+          return `invalid timeTo: ${value}`;
+        }
+      },
+    })
+  ),
 });
 
 export const intervalSchema = schema.object({
@@ -196,7 +207,7 @@ export const deliverySchema = schema.object({
   configIds: schema.arrayOf(schema.string()),
   title: schema.string(),
   textDescription: schema.string(),
-  htmlDescription: schema.string()
+  htmlDescription: schema.string(),
 });
 
 export const reportParamsSchema = schema.object({
@@ -211,7 +222,7 @@ export const reportParamsSchema = schema.object({
     schema.literal(REPORT_TYPE.dashboard),
     schema.literal(REPORT_TYPE.visualization),
     schema.literal(REPORT_TYPE.savedSearch),
-    schema.literal(REPORT_TYPE.notebook)
+    schema.literal(REPORT_TYPE.notebook),
   ]),
   description: schema.string(),
   core_params: schema.conditional(
@@ -266,7 +277,9 @@ export type ReportSchemaType = TypeOf<typeof reportSchema>;
 export type DataReportSchemaType = TypeOf<typeof dataReportSchema>;
 export type VisualReportSchemaType = TypeOf<typeof visualReportSchema>;
 export type ChannelSchemaType = TypeOf<typeof channelSchema>;
-export type OpenSearchDashboardsUserSchemaType = TypeOf<typeof opensearchDashboardsUserSchema>;
+export type OpenSearchDashboardsUserSchemaType = TypeOf<
+  typeof opensearchDashboardsUserSchema
+>;
 export type DeliverySchemaType = TypeOf<typeof deliverySchema>;
 export type TriggerSchemaType = TypeOf<typeof triggerSchema>;
 export type ScheduleSchemaType = TypeOf<typeof scheduleSchema>;

--- a/server/model/index.ts
+++ b/server/model/index.ts
@@ -42,20 +42,20 @@ export const dataReportSchema = schema.object({
       }
     },
   }),
-  timeFrom: schema.string({
+  timeFrom: schema.maybe(schema.string({
     validate(value) {
       if (isNaN(Date.parse(value))) {
         return `invalid timeFrom: ${value}`;
       }
     },
-  }),
-  timeTo: schema.string({
+  })),
+  timeTo: schema.maybe(schema.string({
     validate(value) {
       if (isNaN(Date.parse(value))) {
         return `invalid timeTo: ${value}`;
       }
     },
-  }),
+  })),
   report_format: schema.oneOf([schema.literal(FORMAT.csv), schema.literal(FORMAT.xlsx)]),
   limit: schema.number({ defaultValue: DEFAULT_MAX_SIZE, min: 0 }),
   excel: schema.boolean({ defaultValue: true }),
@@ -87,20 +87,20 @@ export const visualReportSchema = schema.object({
       }
     },
   }),
-  timeFrom: schema.string({
+  timeFrom: schema.maybe(schema.string({
     validate(value) {
       if (isNaN(Date.parse(value))) {
         return `invalid timeFrom: ${value}`;
       }
     },
-  }),
-  timeTo: schema.string({
+  })),
+  timeTo: schema.maybe(schema.string({
     validate(value) {
       if (isNaN(Date.parse(value))) {
         return `invalid timeTo: ${value}`;
       }
     },
-  }),
+  })),
 });
 
 export const intervalSchema = schema.object({

--- a/server/routes/utils/converters/backendToUi.ts
+++ b/server/routes/utils/converters/backendToUi.ts
@@ -192,8 +192,8 @@ const getVisualReportCoreParams = (
   duration: string,
   baseUrl: string,
   origin: string,
-  timeFrom: string,
-  timeTo: string
+  timeFrom: string | null = null,
+  timeTo: string | null = null
 ): VisualReportSchemaType => {
   let res: VisualReportSchemaType = {
     base_url: baseUrl,
@@ -202,8 +202,8 @@ const getVisualReportCoreParams = (
     footer: footer,
     time_duration: duration,
     origin: origin,
-    timeFrom: timeFrom,
-    timeTo: timeTo,
+    timeFrom: timeFrom ?? undefined,
+    timeTo: timeTo ?? undefined,
   };
   return res;
 };
@@ -243,8 +243,8 @@ const getDataReportCoreParams = (
   duration: string,
   baseUrl: string,
   origin: string,
-  timeFrom: string,
-  timeTo: string
+  timeFrom: string | null = null,
+  timeTo: string | null = null
 ): DataReportSchemaType => {
   let res: DataReportSchemaType = {
     base_url: baseUrl,
@@ -253,8 +253,8 @@ const getDataReportCoreParams = (
     time_duration: duration,
     saved_search_id: sourceId,
     origin: origin,
-    timeFrom: timeFrom,
-    timeTo: timeTo,
+    timeFrom: timeFrom ?? undefined,
+    timeTo: timeTo ?? undefined,
   };
   return res;
 };


### PR DESCRIPTION
### Description
When loading reports which did not have a time from and time to there was an error thrown saying error generating report, making the parameters optional 
<img width="1011" alt="image" src="https://github.com/user-attachments/assets/fe5851b2-8819-4cf1-8592-12c2221becb4" />


### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
