### PR TITLE
Format IPv6 hostnames

### DIFF
--- a/server/routes/reportDefinition.ts
+++ b/server/routes/reportDefinition.ts
@@ -48,6 +48,11 @@ export default function (router: IRouter, config: ReportingConfig) {
       const logger = context.reporting_plugin.logger;
       // input validation
       try {
+        //Since hostname is used with a port, if hostname is IPv6 format it will need to be 
+        //surrounded by brackets per protocol rules
+        if (hostname?.includes(":")) {
+          hostname = "[" + hostname + "]";
+        }
         reportDefinition.report_params.core_params.origin = `${protocol}://${hostname}:${port}${basePath}`;
         reportDefinition = await validateReportDefinition(
           context.core.opensearch.legacy.client,


### PR DESCRIPTION
### Description
Fixes issue where an error is thrown when attempting to create a report definition when using IPv6 hostname.  Validation of the create definition URL fails because no square brackets are around the hostname when also defining a port.
If server.host is set to "::", the URL is then constructed as "https://:::5601/".  This is not a valid IPv6 URL and should be "https://[::]:5601/".
The fix is to add those brackets around the hostname when dealing with an IPv6 hostname.

### Issues Resolved
#490 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
