### PR TITLE
[Bug] Reporting Popover UI

### DIFF
--- a/.cypress/integration/04-download.spec.ts
+++ b/.cypress/integration/04-download.spec.ts
@@ -31,7 +31,7 @@ describe('Cypress', () => {
     cy.get('#downloadReport > span:nth-child(1) > span:nth-child(1)').click({ force: true });
 
     // download PDF
-    cy.get('#generatePDF > span:nth-child(1) > span:nth-child(2)').click({ force: true });
+    cy.get('#generatePDF').click({ force: true });
 
     cy.get('#reportGenerationProgressModal');
   });

--- a/public/components/context_menu/context_menu.js
+++ b/public/components/context_menu/context_menu.js
@@ -21,6 +21,7 @@ import {
   contextMenuViewReports,
   displayLoadingModal,
   getTimeFieldsFromUrl,
+  positionReportPopover,
   replaceQueryURL,
 } from './context_menu_helpers';
 import {
@@ -150,6 +151,9 @@ $(function () {
           ? popoverMenuDiscover(getUuidFromUrl())
           : popoverMenu(getUuidFromUrl());
         popoverScreen[0].appendChild(reportPopover.children[0]);
+
+        positionReportPopover();
+      
         $('#reportPopover').show();
       } catch (e) {
         console.log('error displaying menu:', e);

--- a/public/components/context_menu/context_menu_helpers.js
+++ b/public/components/context_menu/context_menu_helpers.js
@@ -139,3 +139,28 @@ export const replaceQueryURL = (pageUrl) => {
   );
   return queryUrl;
 };
+
+// Dynamic position function to call after inserting the popover
+export const positionReportPopover = (triggerElementId = 'downloadReport') => {
+  const popover = document.getElementById('reportPopover');
+  const trigger = document.getElementById(triggerElementId);
+
+  if (popover && trigger) {
+    const rect = trigger.getBoundingClientRect();
+    const scrollTop = window.scrollY || document.documentElement.scrollTop;
+
+    popover.style.top = `${rect.bottom + scrollTop + 16}px`;
+    popover.style.left = `${rect.left}px`;
+    popover.style.right = 'auto';
+
+    const arrow = popover.querySelector('.euiPopover__panelArrow');
+    if (arrow) {
+      const popoverWidth = popover.offsetWidth;
+      const triggerCenter = rect.left + rect.width / 2;
+      const popoverLeft = rect.left;
+      const arrowOffset = triggerCenter - popoverLeft - 8;
+
+      arrow.setAttribute('style', `left: ${arrowOffset}px; top: 0px;`);
+    }
+  }
+};

--- a/public/components/context_menu/context_menu_ui.js
+++ b/public/components/context_menu/context_menu_ui.js
@@ -28,106 +28,76 @@ export const popoverMenu = (savedObjectAvailable) => {
           'Save this Visualization/Dashboard to enable PDF/PNG reports.',
       });
 
-  const arrowRight = '100px';
-  const popoverRight = '170px';
-
   return `
     <div>
       <div data-focus-guard="true" tabindex="-1" style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;">
-    </div>
-      <div data-focus-guard="true" tabindex="-1" style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;">
-    </div>
-    <div data-focus-lock-disabled="disabled">
-       <div class="euiPanel euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen euiPopover__panel-withTitle" aria-live="assertive" role="dialog" aria-modal="true" style="top: 100.972px; right: ${popoverRight}; z-index: 3000;" id="reportPopover">
-          <div class="euiPopover__panelArrow euiPopover__panelArrow--bottom" style="right: ${arrowRight}; top: 0px;">
-        </div>
+      </div>
+      <div data-focus-lock-disabled="disabled">
+        <div class="euiPanel euiPopover__panel euiPopover__panel--bottom euiPopover__panel-isOpen euiPopover__panel-withTitle report-popover-panel" aria-live="assertive" role="dialog" aria-modal="true" id="reportPopover" style="position: absolute; z-index: 3000;">
+          <div class="euiPopover__panelArrow euiPopover__panelArrow--bottom" style="right: 100px; top: 0px;">
+          </div>
           <div>
-             <div class="euiContextMenu" data-test-subj="shareContextMenu" style="width: 235px;">
-                <div class="euiContextMenuPanel" tabindex="0">
-                   <div class="euiContextMenuPanelTitle euiContextMenuPanelTitle--small">
-                      <span data-html2canvas-ignore class="euiContextMenu__itemLayout">
+            <div class="euiContextMenu" data-test-subj="shareContextMenu" style="width: 235px;">
+              <div class="euiContextMenuPanel" tabindex="0">
+                <div class="euiContextMenuPanelTitle euiContextMenuPanelTitle--small">
+                  <span data-html2canvas-ignore class="euiContextMenu__itemLayout">
                       ${i18n.translate(
                         'opensearch.reports.menu.visual.generateReport',
                         { defaultMessage: 'Generate report' }
                       )}
-                      </span>
-                   </div>
-                   <div>
-                   <div class="euiText euiText--small" style="padding-left: 10px; padding-right: 10px; margin-top: 10px; box-decoration-break: clone; display: inline-block;">
-                    <p>${message}</p>
-                   </div>
-                   <div>
-                      <div>
-                         <${button} class="${buttonClass}" type="button" data-test-subj="downloadPanel-GeneratePDF" id="generatePDF">
-                            <span data-html2canvas-ignore class="euiContextMenu__itemLayout">
-                            <svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" class="euiIcon euiIcon--medium euiIcon-isLoaded euiContextMenu__icon" focusable="false" role="img" aria-hidden="true"><path d="M9 9.114l1.85-1.943a.52.52 0 01.77 0c.214.228.214.6 0 .829l-1.95 2.05a1.552 1.552 0 01-2.31 0L5.41 8a.617.617 0 010-.829.52.52 0 01.77 0L8 9.082V.556C8 .249 8.224 0 8.5 0s.5.249.5.556v8.558z"></path><path d="M16 13.006V10h-1v3.006a.995.995 0 01-.994.994H3.01a.995.995 0 01-.994-.994V10h-1v3.006c0 1.1.892 1.994 1.994 1.994h10.996c1.1 0 1.994-.893 1.994-1.994z"></path></svg>
-                               <span data-html2canvas-ignore class="euiContextMenuItem__text">${i18n.translate(
-                                 'opensearch.reports.menu.visual.downloadPdf',
-                                 { defaultMessage: 'Download PDF' }
-                               )}</span>
-                            </span>
-                         </button>
-                         <${button} class="${buttonClass}" type="button" data-test-subj="downloadPanel-GeneratePNG" id="generatePNG">
-                            <span data-html2canvas-ignore class="euiContextMenu__itemLayout">
-                            <svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" class="euiIcon euiIcon--medium euiIcon-isLoaded euiContextMenu__icon" focusable="false" role="img" aria-hidden="true"><path d="M9 9.114l1.85-1.943a.52.52 0 01.77 0c.214.228.214.6 0 .829l-1.95 2.05a1.552 1.552 0 01-2.31 0L5.41 8a.617.617 0 010-.829.52.52 0 01.77 0L8 9.082V.556C8 .249 8.224 0 8.5 0s.5.249.5.556v8.558z"></path><path d="M16 13.006V10h-1v3.006a.995.995 0 01-.994.994H3.01a.995.995 0 01-.994-.994V10h-1v3.006c0 1.1.892 1.994 1.994 1.994h10.996c1.1 0 1.994-.893 1.994-1.994z"></path></svg>
-                               <span data-html2canvas-ignore class="euiContextMenuItem__text">${i18n.translate(
-                                 'opensearch.reports.menu.visual.downloadPng',
-                                 { defaultMessage: 'Download PNG' }
-                               )}</span>
-                            </span>
-                         </button>
-                      </div>
-                   </div>
-                   <div class="euiContextMenuPanelTitle euiContextMenuPanelTitle--small">
-                    <span data-html2canvas-ignore class="euiContextMenu__itemLayout">
-                      ${i18n.translate(
-                        'opensearch.reports.menu.visual.scheduleAndShare',
-                        { defaultMessage: 'Schedule and share' }
-                      )}
-                    </span>
-                  </div>
-                  <div>
-                    <${button} class="${buttonClass}" type="button" data-test-subj="downloadPanel-GeneratePDF" id="createReportDefinition">
-                      <span data-html2canvas-ignore class="euiContextMenu__itemLayout">
-                        <svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" class="euiIcon euiIcon--medium euiIcon-isLoaded euiContextMenu__icon" focusable="false" role="img" aria-hidden="true"><path d="M14 4v-.994C14 2.45 13.55 2 12.994 2H11v1h-1V2H6v1H5V2H3.006C2.45 2 2 2.45 2 3.006v9.988C2 13.55 2.45 14 3.006 14h9.988C13.55 14 14 13.55 14 12.994V5H2V4h12zm-3-3h1.994C14.102 1 15 1.897 15 3.006v9.988A2.005 2.005 0 0112.994 15H3.006A2.005 2.005 0 011 12.994V3.006C1 1.898 1.897 1 3.006 1H5V0h1v1h4V0h1v1zM4 7h2v1H4V7zm3 0h2v1H7V7zm3 0h2v1h-2V7zM4 9h2v1H4V9zm3 0h2v1H7V9zm3 0h2v1h-2V9zm-6 2h2v1H4v-1zm3 0h2v1H7v-1zm3 0h2v1h-2v-1z" fill-rule="evenodd"></path></svg>
-                        <span data-html2canvas-ignore class="euiContextMenuItem__text">${i18n.translate(
-                          'opensearch.reports.menu.visual.createReportDefinition',
-                          { defaultMessage: 'Create report definition' }
-                        )}</span>
-                        </svg>
-                      </span>
-                    </button>
-                  </div>
-                  <div class="euiContextMenuPanelTitle euiContextMenuPanelTitle--small">
-                    <span data-html2canvas-ignore class="euiContextMenu__itemLayout">
-                      ${i18n.translate('opensearch.reports.menu.visual.view', {
-                        defaultMessage: 'View',
-                      })}
-                    </span>
-                  </div>
-                  <div>
-                    <button class="euiContextMenuItem" type="button" data-test-subj="downloadPanel-GeneratePDF" id="viewReports">
-                      <span data-html2canvas-ignore class="euiContextMenu__itemLayout">
-                        <svg id="reports-icon" width="16px" height="16px" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" class="euiIcon euiIcon--medium euiIcon-isLoaded euiContextMenu__icon">
-                            <g transform="translate(1.000000, 0.000000)" fill="currentColor">
-                              <path d="M9.8,0 L1,0 C0.448,0 0,0.448 0,1 L0,15 C0,15.552 0.448,16 1,16 L13,16 C13.552,16 14,15.552 14,15 L14,4.429 C14,4.173 13.902,3.926 13.726,3.74 L10.526,0.312 C10.337,0.113 10.074,0 9.8,0 M9,1 L9,4.5 C9,4.776 9.224,5 9.5,5 L9.5,5 L13,5 L13,15 L1,15 L1,1 L9,1 Z M11.5,13 L2.5,13 L2.5,14 L11.5,14 L11.5,13 Z M10.8553858,6.66036578 L7.924,9.827 L5.42565136,8.13939866 L2.63423628,11.1343544 L3.36576372,11.8161664 L5.574,9.446 L8.07559521,11.1358573 L11.5892757,7.33963422 L10.8553858,6.66036578 Z M7.5,4 L2.5,4 L2.5,5 L7.5,5 L7.5,4 Z M7.5,2 L2.5,2 L2.5,3 L7.5,3 L7.5,2 Z"></path>
-                            </g>
-                        </svg>
-                          <span data-html2canvas-ignore class="euiContextMenuItem__text">${i18n.translate(
-                            'opensearch.reports.menu.visual.viewReports',
-                            { defaultMessage: 'View reports' }
-                          )}</span>
-                          </svg>
-                      </span>
-                    </button>
-                    </div>
+                  </span>
                 </div>
-             </div>
+                <div>
+                  <div class="euiText euiText--small" style="padding-left: 10px; padding-right: 10px; margin-top: 10px; box-decoration-break: clone; display: inline-block;">
+                    <p>${message}</p>
+                  </div>
+                  <div>
+                    <div>
+                      <${button} class="${buttonClass}" type="button" data-test-subj="downloadPanel-GeneratePDF" id="generatePDF">
+                        <span data-html2canvas-ignore class="euiContextMenu__itemLayout">
+                          <span data-html2canvas-ignore class="euiContextMenuItem__text">${i18n.translate('opensearch.reports.menu.visual.downloadPdf', { defaultMessage: 'Download PDF' })}</span>
+                        </span>
+                      </${button}>
+                      <${button} class="${buttonClass}" type="button" data-test-subj="downloadPanel-GeneratePNG" id="generatePNG">
+                        <span data-html2canvas-ignore class="euiContextMenu__itemLayout">
+                          <span data-html2canvas-ignore class="euiContextMenuItem__text">${i18n.translate('opensearch.reports.menu.visual.downloadPng', { defaultMessage: 'Download PNG' })}</span>
+                        </span>
+                      </${button}>
+                    </div>
+                  </div>
+                </div>
+                <div class="euiContextMenuPanelTitle euiContextMenuPanelTitle--small">
+                  <span data-html2canvas-ignore class="euiContextMenu__itemLayout">
+                    ${i18n.translate('opensearch.reports.menu.visual.scheduleAndShare', { defaultMessage: 'Schedule and share' })}
+                  </span>
+                </div>
+                <div>
+                  <${button} class="${buttonClass}" type="button" data-test-subj="downloadPanel-GeneratePDF" id="createReportDefinition">
+                    <span data-html2canvas-ignore class="euiContextMenu__itemLayout">
+                      <span data-html2canvas-ignore class="euiContextMenuItem__text">${i18n.translate('opensearch.reports.menu.visual.createReportDefinition', { defaultMessage: 'Create report definition' })}</span>
+                    </span>
+                  </${button}>
+                </div>
+                <div class="euiContextMenuPanelTitle euiContextMenuPanelTitle--small">
+                  <span data-html2canvas-ignore class="euiContextMenu__itemLayout">
+                    ${i18n.translate('opensearch.reports.menu.visual.view', { defaultMessage: 'View' })}
+                  </span>
+                </div>
+                <div>
+                  <button class="euiContextMenuItem" type="button" data-test-subj="downloadPanel-GeneratePDF" id="viewReports">
+                    <span data-html2canvas-ignore class="euiContextMenu__itemLayout">
+                      <span data-html2canvas-ignore class="euiContextMenuItem__text">${i18n.translate('opensearch.reports.menu.visual.viewReports', { defaultMessage: 'View reports' })}</span>
+                    </span>
+                  </button>
+                </div>
+              </div>
+            </div>
           </div>
-       </div>
+        </div>
+      </div>
+      <div data-focus-guard="true" tabindex="-1" style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"></div>
     </div>
-    <div data-focus-guard="true" tabindex="-1" style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"></div>
-    `;
+  `;
 };
 
 // TODO: merge this function and popoverMenu() into one


### PR DESCRIPTION
### Description
The reporting pop-over for dashboards was set to a fixed position, if the user scrolled down the page and clicked it, it would be hidden as it appeared at the top.
This change makes it relative so the pop-over always opens correctly.

Before:

https://github.com/user-attachments/assets/939c3f93-ef4e-4c16-ae49-b7a2c0f3a40a


After:


https://github.com/user-attachments/assets/0a5d90c6-9119-4ddc-92d0-70ec528cb074

Also updated the failing cypress test. The original code was looking for 
cy.get('#generatePDF > span:nth-child(1) > span:nth-child(2)').click({ force: true });
but only one exist
<img width="1567" alt="Cypress" src="https://github.com/user-attachments/assets/417e2835-45ea-4b46-a13d-9dd29739bbcc" />
Changed to :  cy.get('#generatePDF').click({ force: true }); and is passing

### Issues Resolved
https://github.com/opensearch-project/dashboards-reporting/issues/401

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
