### PR TITLE
Add Adam and Sumukh as maintainers for dashboards-reporting

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @pjfitzgibbons @ps48 @kavithacm @derek-ho @joshuali925 @dai-chen @YANG-DB @rupal-bq @mengweieric @vamsi-amazon @swiddis @penghuo @seankao-az @anirudha
+* @ps48 @joshuali925 @dai-chen @mengweieric @vamsi-amazon @swiddis @penghuo @anirudha @tackadam @sumukhswamy

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,22 +4,18 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 ## Current Maintainers
 
-| Maintainer        | GitHub ID                                         | Affiliation |
-| ----------------- | ------------------------------------------------- | ----------- |
-| Eric Wei          | [mengweieric](https://github.com/mengweieric)     | Amazon      |
-| Joshua Li         | [joshuali925](https://github.com/joshuali925)     | Amazon      |
-| Shenoy Pratik     | [ps48](https://github.com/ps48)                   | Amazon      |
-| Kavitha Mohan     | [kavithacm](https://github.com/kavithacm)         | Amazon      |
-| Rupal Mahajan     | [rupal-bq](https://github.com/rupal-bq)           | Amazon      |
-| Derek Ho          | [derek-ho](https://github.com/derek-ho)           | Amazon      |
-| Lior Perry        | [YANG-DB](https://github.com/YANG-DB)             | Amazon      |
-| Peter Fitzgibbons | [pjfitzgibbons](https://github.com/pjfitzgibbons) | Amazon      |
-| Simeon Widdis     | [swiddis](https://github.com/swiddis)             | Amazon      |
-| Chen Dai          | [dai-chen](https://github.com/dai-chen)           | Amazon      |
-| Vamsi Manohar     | [vamsimanohar](https://github.com/vamsimanohar)   | Amazon      |
-| Peng Huo          | [penghuo](https://github.com/penghuo)             | Amazon      |
-| Sean Kao          | [seankao-az](https://github.com/seankao-az)       | Amazon      |
-| Anirudha Jadhav   | [anirudha](https://github.com/anirudha)           | Amazon      |
+| Maintainer                | GitHub ID                                              | Affiliation |
+| ------------------------- | ----------------------------------------------------- | ----------- |
+| Eric Wei                  | [mengweieric](https://github.com/mengweieric)          | Amazon      |
+| Joshua Li                 | [joshuali925](https://github.com/joshuali925)          | Amazon      |
+| Shenoy Pratik             | [ps48](https://github.com/ps48)                        | Amazon      |
+| Simeon Widdis             | [swiddis](https://github.com/swiddis)                  | Amazon      |
+| Chen Dai                  | [dai-chen](https://github.com/dai-chen)                | Amazon      |
+| Vamsi Manohar             | [vamsimanohar](https://github.com/vamsimanohar)        | Amazon      |
+| Peng Huo                  | [penghuo](https://github.com/penghuo)                  | Amazon      |
+| Anirudha Jadhav           | [anirudha](https://github.com/anirudha)                | Amazon      |
+| Adam Tackett              | [tackadam](https://github.com/TackAdam)                | Amazon      |
+| Sumukh Hanumantha Swamy   | [sumukhswamy](https://github.com/sumukhswamy)          | Amazon      |
 
 
 ## Emeritus Maintainers
@@ -32,3 +28,9 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Eugene Lee        | [eugenesk24](https://github.com/eugenesk24)             | Amazon      |
 | Zhongnan Su       | [zhongnansu](https://github.com/zhongnansu)             | Amazon      |
 | Sean Li           | [sejli](https://github.com/sejli)                       | Amazon      |
+| Sean Kao          | [seankao-az](https://github.com/seankao-az)             | Amazon      |
+| Lior Perry        | [YANG-DB](https://github.com/YANG-DB)                   | Amazon      |
+| Peter Fitzgibbons | [pjfitzgibbons](https://github.com/pjfitzgibbons)       | Amazon      |
+| Kavitha Mohan     | [kavithacm](https://github.com/kavithacm)               | Amazon      |
+| Rupal Mahajan     | [rupal-bq](https://github.com/rupal-bq)                 | Amazon      |
+| Derek Ho          | [derek-ho](https://github.com/derek-ho)                 | Amazon      |


### PR DESCRIPTION
### Description
Adam Tackett (@tackadam)and Sumukh Swamy (@sumukhhs) as new maintainers in the repository.
* Adam: 9 closed/merged pull request including UI updates and bug fixes.
* Sumukh: 12 closed/merged pull request including bug fixes, cve corrections, and MDS enhancements.
Both have been engaged in issues and active in reviewing PR’s.

Reporting has some maintainers moved to emeritus status:
Kavitha Mohan: kavithacm
Rupal Mahajan: rupal-bq
Lior Perry: YANG-DB
Peter Fitzgibbons: pjfitzibbons
Derek Ho: derek-ho

### Issues Resolved
https://github.com/opensearch-project/.github/issues/346


### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
