### PR TITLE
fix for tenant issue when redirecting from discover

### DIFF
--- a/public/components/context_menu/context_menu.js
+++ b/public/components/context_menu/context_menu.js
@@ -136,7 +136,12 @@ const generateInContextReport = async (
 
 // try to match uuid and user entered custom-id followed by '?' in URL, which would be the saved search id for discover URL
 // custom id example: v1s-f00-b4r1-01, Filebeat-Apache-Dashboard-ecs,
-const getUuidFromUrl = () => window.location.href.match(/([0-9a-zA-Z-]+)\?/);
+const getUuidFromUrl = () => {
+  let href = window.location.href;
+  // Remove security_tenant parameter to avoid interference
+  href = href.replace(/[?&]security_tenant=[^&#]*/g, '');
+  return href.match(/([0-9a-zA-Z-]+)\?/);
+};
 const isDiscover = () => window.location.href.includes('discover');
 
 // open Download drop-down


### PR DESCRIPTION
### Description

When trying to generate CSV/XLSX reports from saved searches in the data explorer with security tenants enabled, the report generation fails because the system incorrectly identifies the saved search.

URLs like discover?security_tenant=global#/view/3ba638e0-b894-11e8-a6d9-e546fe2bba5f were being parsed incorrectly
Instead of extracting the saved search ID 3ba638e0-b894-11e8-a6d9-e546fe2bba5f, the system was getting discover
This caused report generation to fail with validation errors
Updated the URL parsing logic to correctly extract saved search IDs from data explorer URLs, even when security tenant parameters are present.

### Issues Resolved
https://github.com/opensearch-project/dashboards-reporting/issues/535

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
