### PR TITLE
feat: add waitForDataRender() function

### DIFF
--- a/public/components/visual_report/constants.ts
+++ b/public/components/visual_report/constants.ts
@@ -20,6 +20,7 @@ export enum VISUAL_REPORT_TYPE {
 export enum SELECTOR {
   dashboard = '#dashboardViewport',
   visualization = '.visEditor__content',
+  visualizations = '.visualize',
   notebook = '.euiPageBody',
 }
 


### PR DESCRIPTION
### Description
Fixes an issue with visual report where it gets generated before all visualizations are loaded.

### Issues Resolved
https://github.com/opensearch-project/dashboards-reporting/issues/633

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
