### PR TITLE
fix: create report from context menu

### DIFF
--- a/public/components/context_menu/context_menu_helpers.js
+++ b/public/components/context_menu/context_menu_helpers.js
@@ -49,17 +49,16 @@ export const contextMenuCreateReportDefinition = (baseURI) => {
   const timeRanges = getTimeFieldsFromUrl();
 
   // check report source
-  if (/\/app\/dashboards/.test(baseURI)) {
+  if (/\/app\/data-explorer\/dashboards/.test(baseURI)) {
     reportSource = 'dashboard:';
-  } else if (/\/app\/visualize/.test(baseURI)) {
+  } else if (/\/app\/data-explorer\/visualize/.test(baseURI)) {
     reportSource = 'visualize:';
-  } else if (/\/app\/discover/.test(baseURI)) {
+  } else if (/\/app\/data-explorer\/discover/.test(baseURI)) {
     reportSource = 'discover:';
   }
   reportSource += reportSourceId.toString();
-  window.location.assign(
-    `reports-dashboards#/create?previous=${reportSource}?timeFrom=${timeRanges.time_from.toISOString()}?timeTo=${timeRanges.time_to.toISOString()}`
-  );
+  applicationService.getApplication().navigateToApp(PLUGIN_ID, { path: `#/create?previous=${reportSource}?timeFrom=${timeRanges.time_from.toISOString()}?timeTo=${timeRanges.time_to.toISOString()}`});
+
 };
 
 export const displayLoadingModal = () => {


### PR DESCRIPTION
### Description
Fixes `contextMenuCreateReportDefinition()`.

There were two things wrong with it:

1. Report source check was missing `data-explorer` in path test so it would yield empty result.
2. `location.assign()` was appending path at the end of current path, resulting in `<domain>/app/data-explorer/discover/reports-dashboards#/create?<params>` which was of course wrong. Switched it to `navigateToApp()`.

### Issues Resolved
https://github.com/opensearch-project/dashboards-reporting/issues/576

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
