### PR TITLE
Use /api/observability/notebooks/savedNotebook for list notebooks route

### DIFF
--- a/public/components/report_definitions/report_settings/report_settings.tsx
+++ b/public/components/report_definitions/report_settings/report_settings.tsx
@@ -684,7 +684,7 @@ export function ReportSettings(props: ReportSettingProps) {
       });
 
     await httpClientProps
-      .get('../api/observability/notebooks/')
+      .get('../api/observability/notebooks/savedNotebook')
       .catch((error: any) => {
         console.error(
           'error fetching notebooks, retrying with legacy api',


### PR DESCRIPTION
### Description

This PR fixes a regression introduced by https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6233. Before https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6233, route matching was more lenient so `/api/observability/notebooks/` could resolve accordingly.

Since 3.0.0 there's been stricter route matching to ensure routes do not end with trailing slash (otherwise its redirected to non-trailing slash route). This PR uses the correct route name.

### Issues Resolved

Will file issue. It manifests when using Cognito auth in Amazon OpenSearch Service where the user is logged out when going to the Create Report page in OpenSearch >= 3.0.0

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
