### PR TITLE
Prepend UTF-8 BOM to generated CSV files

### DIFF
--- a/server/routes/utils/__tests__/dataReportHelpers.test.ts
+++ b/server/routes/utils/__tests__/dataReportHelpers.test.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { getOpenSearchData } from '../dataReportHelpers';
+import { getOpenSearchData, convertToCSV } from '../dataReportHelpers';
 
 jest.mock('../excelBuilder', () => ({
   ExcelBuilder: jest.fn().mockImplementation(() => ({
@@ -359,5 +359,23 @@ describe('test traverse preserves selected field order', () => {
 
     expect(keys1).toEqual(['field_b', 'field_a', 'field_c']);
     expect(keys2).toEqual(['field_b', 'field_a', 'field_c']);
+  });
+});
+
+describe('convertToCSV', () => {
+  test('should prepend UTF-8 BOM to CSV output', async () => {
+    const dataset = [[{ name: 'test', value: 'hello' }]];
+    const result = await convertToCSV(dataset, ',');
+    expect(result.charCodeAt(0)).toBe(0xfeff);
+    expect(result.startsWith('\uFEFF')).toBe(true);
+  });
+
+  test('should contain correct CSV content after BOM', async () => {
+    const dataset = [[{ name: "it's", city: 'Zürich' }]];
+    const result = await convertToCSV(dataset, ',');
+    const csvContent = result.substring(1); // skip BOM
+    expect(csvContent).toContain('name');
+    expect(csvContent).toContain("it's");
+    expect(csvContent).toContain('Zürich');
   });
 });

--- a/server/routes/utils/dataReportHelpers.ts
+++ b/server/routes/utils/dataReportHelpers.ts
@@ -231,7 +231,8 @@ export const convertToCSV = async (dataset, csvSeparator) => {
   await converter.json2csvAsync(dataset[0], options).then((csv) => {
     convertedData = csv;
   });
-  return convertedData;
+  // Prepend UTF-8 BOM so Excel correctly detects encoding
+  return '\uFEFF' + convertedData;
 };
 
 function flattenHits(


### PR DESCRIPTION
### Description

Prepends a UTF-8 BOM (`\uFEFF`) to generated CSV files so that Excel and other spreadsheet applications correctly detect the encoding. This fixes the issue where special characters (e.g. `'`) display as garbled text (`â€™`) when opening CSV exports in Excel.

### Changes

- Added UTF-8 BOM prefix in `convertToCSV()` in `dataReportHelpers.ts`
- Added unit tests verifying BOM presence and correct CSV content

### Testing

Unit tests pass:
```
PASS server/routes/utils/__tests__/dataReportHelpers.test.ts
  convertToCSV
    ✓ should prepend UTF-8 BOM to CSV output
    ✓ should contain correct CSV content after BOM
```

### Issues Resolved

Resolves #545