### PR TITLE
Fix edit report definition race condition and missing origin header

### DIFF
--- a/public/components/report_definitions/report_settings/report_settings.tsx
+++ b/public/components/report_definitions/report_settings/report_settings.tsx
@@ -704,23 +704,29 @@ export function ReportSettings(props: ReportSettingProps) {
   };
 
   useEffect(() => {
-    let reportSourceOptions = {};
-    let editData = {};
-    if (edit) {
-      defaultConfigurationEdit(httpClientProps).then(async (response) => {
-        editData = response;
-      });
-    }
-    defaultConfigurationCreate(httpClientProps).then(async (response) => {
-      reportSourceOptions = response;
+    // Serialize the two fetches so editData is guaranteed to be populated
+    // before setDefaultEditValues runs. When run in parallel, the create-side
+    // dropdown fetches can finish before the edit-side fetch (common when
+    // security is disabled and there's no per-call auth overhead), causing
+    // the form to be hydrated from an empty editData — base_url stays '',
+    // and client-side validation then blocks Save.
+    const loadConfiguration = async () => {
+      let editData = {};
+      if (edit) {
+        editData = await defaultConfigurationEdit(httpClientProps);
+      }
+      const reportSourceOptions = await defaultConfigurationCreate(
+        httpClientProps
+      );
       // if coming from in-context menu
       if (window.location.href.indexOf('?') > -1) {
-        setInContextDefaultConfiguration(response);
+        setInContextDefaultConfiguration(reportSourceOptions);
       }
       if (edit) {
         setDefaultEditValues(editData, reportSourceOptions);
       }
-    });
+    };
+    loadConfiguration();
   }, []);
 
   const displayDashboardSelect =

--- a/server/routes/reportDefinition.ts
+++ b/server/routes/reportDefinition.ts
@@ -106,8 +106,17 @@ export default function (router: IRouter, config: ReportingConfig) {
       const logger = context.reporting_plugin.logger;
       // input validation
       try {
+        // Chromium does not always send the Origin header for same-origin
+        // requests (e.g. PUT from the in-app fetch on localhost), so fall
+        // back to the configured OSD origin like the create handler does.
+        // Without this fallback, validation rejects the body with
+        // `[report_params.core_params.origin]: expected value of type
+        // [string] but got [undefined]` and the request 400s.
         reportDefinition.report_params.core_params.origin =
-          request.headers.origin;
+          request.headers.origin ||
+          (request.headers.referer
+            ? new URL(request.headers.referer as string).origin
+            : `${protocol}://${hostname}:${port}${basePath}`);
         reportDefinition = await validateReportDefinition(
           context.core.opensearch.legacy.client,
           reportDefinition,


### PR DESCRIPTION
### Description

Fix two bugs that cause editing a report definition to fail:

1. **Race condition in `ReportSettings` useEffect**: `defaultConfigurationEdit` and `defaultConfigurationCreate` were fetched in parallel, but the `.then()` on create used `editData` which may not have been populated yet. Serialized the fetches so `editData` is guaranteed to be available before `setDefaultEditValues` runs.

2. **Missing `Origin` header in update route**: Chromium omits the `Origin` header for same-origin PUT requests. The update handler now falls back to the `Referer` header or the configured OSD origin (matching the existing create handler behavior).

### Issues Resolved

Resolves #741

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed off.