### PR TITLE
Improve XLSX report download to decode data URI directly

### DIFF
--- a/public/components/main/__tests__/main_utils.test.tsx
+++ b/public/components/main/__tests__/main_utils.test.tsx
@@ -26,46 +26,46 @@ import httpClientMock from '../../../../test/httpMockClient';
 
 describe('main_utils tests', () => {
   global.URL.createObjectURL = jest.fn();
-  let mockElement = document.createElement('a');
+  const mockElement = document.createElement('a');
   mockElement.download = 'string';
   mockElement.click = function name() {};
   sinon.stub(document, 'createElement').returns(mockElement);
 
-  test('test humanReadableDate', () => {
+  test('humanReadableDate', () => {
     const readableDate = new Date(2018, 11, 24, 10, 33, 30);
     const humanReadable = humanReadableDate(readableDate);
 
     expect(humanReadable).toBe('Mon Dec 24 2018 @ 10:33:30 AM');
   });
 
-  test('test extractFileName', () => {
+  test('extractFileName', () => {
     const fullFile = 'test_file_name_extracted_correctly.pdf';
     const fileName = extractFilename(fullFile);
 
     expect(fileName).toBe('test_file_name_extracted_correctly');
   });
 
-  test('test extractFileFormat', () => {
+  test('extractFileFormat', () => {
     const fullFile = 'test_file_format_extracted_correctly.png';
     const fileFormat = extractFileFormat(fullFile);
 
     expect(fileFormat).toBe('png');
   });
 
-  test('test getFileFormatPrefix', () => {
+  test('getFileFormatPrefix', () => {
     const fileFormat = 'pdf';
     const fileFormatPrefix = getFileFormatPrefix(fileFormat);
 
     expect(fileFormatPrefix).toBe('data:pdf;base64,');
   });
 
-  test('test addReportsTableContent', () => {
+  test('addReportsTableContent', () => {
     const reportsTableItems = addReportsTableContent(reportTableMockResponse);
 
     expect(reportsTableItems).toStrictEqual(mockReportsTableItems);
   });
 
-  test('test addReportDefinitionsTableContent', () => {
+  test('addReportDefinitionsTableContent', () => {
     const reportDefinitionsTableItems = addReportDefinitionsTableContent(
       reportDefinitionsTableMockResponse
     );
@@ -75,14 +75,14 @@ describe('main_utils tests', () => {
     );
   });
 
-  test('test removeDuplicatePdfFileFormat', () => {
+  test('removeDuplicatePdfFileFormat', () => {
     const duplicateFormat = 'test_duplicate_remove.pdf.pdf';
     const duplicateRemoved = removeDuplicatePdfFileFormat(duplicateFormat);
 
     expect(duplicateRemoved).toBe('test_duplicate_remove.pdf');
   });
 
-  test('test readStreamToFile csv compile', () => {
+  test('readStreamToFile csv', () => {
     const stream =
       'category,customer_gender\n' +
       'c1,Male\n' +
@@ -94,33 +94,59 @@ describe('main_utils tests', () => {
     const fileFormat = 'csv';
     const fileName = 'test_data_report.csv';
     readStreamToFile(stream, fileFormat, fileName);
+    expect(global.URL.createObjectURL).toHaveBeenCalled();
   });
 
-  test('test readStreamToFile pdf compile', () => {
+  test('readStreamToFile xlsx creates blob URL without fetch', async () => {
+    const mockCreateObjectURL = jest.fn().mockReturnValue('blob:mock-url');
+    global.URL.createObjectURL = mockCreateObjectURL;
+
+    const stream =
+      'data:application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;base64,dGVzdA==';
+    const fileFormat = 'xlsx';
+    const fileName = 'test_data_report.xlsx';
+
+    await readStreamToFile(stream, fileFormat, fileName);
+
+    expect(mockCreateObjectURL).toHaveBeenCalled();
+    const blob = mockCreateObjectURL.mock.calls[0][0];
+    expect(blob).toBeInstanceOf(Blob);
+    expect(blob.type).toBe(
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+    );
+    expect(blob.size).toBe(4);
+  });
+
+  test('readStreamToFile pdf', () => {
     const stream = 'data:pdf;base64,zxvniaorbguw40absdoanlsdf';
     const fileFormat = 'pdf';
     const fileName = 'test_pdf_report.pdf';
     readStreamToFile(stream, fileFormat, fileName);
+    expect(global.URL.createObjectURL).not.toHaveBeenCalled();
   });
 
-  test('test generateReport compile', () => {
+  test('generateReportFromDefinitionId', () => {
     const reportDefinitionId = '1';
-    generateReportFromDefinitionId(reportDefinitionId, httpClientMock);
+    expect(
+      generateReportFromDefinitionId(reportDefinitionId, httpClientMock)
+    ).toBeDefined();
   });
 
-  test('test generateReportById compile', () => {
+  test('generateReportById', () => {
     const reportId = '1';
     const handleSuccessToast = jest.fn();
     const handleErrorToast = jest.fn();
-    generateReportById(
-      reportId,
-      httpClientMock,
-      handleSuccessToast,
-      handleErrorToast
-    );
+    expect(
+      generateReportById(
+        reportId,
+        httpClientMock,
+        handleSuccessToast,
+        handleErrorToast
+      )
+    ).toBeDefined();
   });
 
-  test('test generateReportById timeout error handling', async () => {
+  test('generateReportById timeout error handling', async () => {
     expect.assertions(1);
     const reportId = '1';
     const handleSuccessToast = jest.fn();

--- a/public/components/main/main_utils.tsx
+++ b/public/components/main/main_utils.tsx
@@ -118,14 +118,19 @@ export const removeDuplicatePdfFileFormat = (filename: string) => {
   return filename.substring(0, filename.length - 4);
 };
 
-async function getDataReportURL(stream: string, fileFormat: string): Promise<string> {
-  if (fileFormat == 'xlsx') {
-    const response = await fetch(stream);
-    const blob = await response.blob();
-    return URL.createObjectURL(blob);
-  }
+function dataURItoBlob(dataURI: string): Blob {
+  const [header, base64Data] = dataURI.split(',');
+  const mimeType = header.match(/:(.*?);/)?.[1] || 'application/octet-stream';
+  const bytes = Uint8Array.from(atob(base64Data), (c) => c.charCodeAt(0));
+  return new Blob([bytes], { type: mimeType });
+}
 
-  const blob = new Blob([stream]);
+async function getDataReportURL(
+  stream: string,
+  fileFormat: string
+): Promise<string> {
+  const blob =
+    fileFormat === 'xlsx' ? dataURItoBlob(stream) : new Blob([stream]);
   return URL.createObjectURL(blob);
 }
 


### PR DESCRIPTION
  ### Summary

- Replace `fetch()` with direct base64 decoding for XLSX report downloads
  - Extracted a reusable `dataURItoBlob` helper that parses the MIME type from the data URI header and decodes the payload into a Blob in-memory
  - Added unit test for the XLSX download path
  
  ### Description
  
  The XLSX download path was using `fetch()` to convert a base64 data URI into a Blob. 

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
