### PR TITLE
fix(deps): upgrade json-2-csv to ^5.5.11 to resolve CVE-2026-9673

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "jest-fetch-mock": "^3.0.3",
     "jquery": "^3.5.0",
     "jsdom": "^21.1.2",
-    "json-2-csv": "^3.20.0",
+    "json-2-csv": "^5.5.11",
     "jspdf": "^4.2.1",
     "react-id-generator": "^3.0.1",
     "react-mde": "^10.2.1",

--- a/server/routes/utils/dataReportHelpers.ts
+++ b/server/routes/utils/dataReportHelpers.ts
@@ -4,7 +4,7 @@
  */
 
 import esb, { Sort } from 'elastic-builder';
-import converter from 'json-2-csv';
+import { json2csv } from 'json-2-csv';
 import _ from 'lodash';
 import moment from 'moment-timezone';
 import {
@@ -15,40 +15,40 @@ import {
 } from '../../../../../src/plugins/data/common';
 import { ExcelBuilder } from './excelBuilder';
 
-export var metaData = {
-  saved_search_id: <string>null,
-  report_format: <string>null,
-  start: <string>null,
-  end: <string>null,
-  fields: <string>null,
-  type: <string>null,
-  timeFieldName: <string>null,
-  sorting: <string>null,
-  fields_exist: <boolean>false,
-  selectedFields: <any>[],
-  paternName: <string>null,
-  searchSourceJSON: <any>[],
-  dateFields: <any>[],
+export const metaData = {
+  saved_search_id: null as string,
+  report_format: null as string,
+  start: null as string,
+  end: null as string,
+  fields: null as string,
+  type: null as string,
+  timeFieldName: null as string,
+  sorting: null as string,
+  fields_exist: false as boolean,
+  selectedFields: [] as any[],
+  paternName: null as string,
+  searchSourceJSON: [] as any[],
+  dateFields: [] as any[],
 };
 
 // Get the selected columns by the user.
 export const getSelectedFields = async (columns, timeFieldName?: string) => {
   const selectedFields = [];
-  let fields_exist = false;
-  for (let column of columns) {
+  let fieldsExist = false;
+  for (const column of columns) {
     if (column !== '_source') {
-      fields_exist = true;
+      fieldsExist = true;
       selectedFields.push(column);
     } else {
-      fields_exist = false;
+      fieldsExist = false;
       selectedFields.push('_source');
     }
   }
   // Automatically add timeFieldName to selected fields if it exists and user has selected specific fields
-  if (fields_exist && timeFieldName && !selectedFields.includes(timeFieldName)) {
+  if (fieldsExist && timeFieldName && !selectedFields.includes(timeFieldName)) {
     selectedFields.unshift(timeFieldName);
   }
-  metaData.fields_exist = fields_exist;
+  metaData.fields_exist = fieldsExist;
   metaData.selectedFields = selectedFields;
 };
 
@@ -57,14 +57,14 @@ export const getSelectedFields = async (columns, timeFieldName?: string) => {
 export const buildRequestBody = (
   report: any,
   allowLeadingWildcards: boolean,
-  is_count: number
+  isCount: number
 ) => {
-  let esbBoolQuery = esb.boolQuery();
+  const esbBoolQuery = esb.boolQuery();
   const searchSourceJSON = report._source.searchSourceJSON;
   const savedObjectQuery: Query = JSON.parse(searchSourceJSON).query;
   const savedObjectFilter: Filter = JSON.parse(searchSourceJSON).filter;
   const savedObjectConfig: OpenSearchQueryConfig = {
-    allowLeadingWildcards: allowLeadingWildcards,
+    allowLeadingWildcards,
     queryStringOptions: {},
     ignoreFilterIfFieldNotInIndex: false,
   };
@@ -84,12 +84,12 @@ export const buildRequestBody = (
         .lte(report._source.end + 1)
     );
   }
-  if (is_count) {
+  if (isCount) {
     return esb.requestBodySearch().query(esbBoolQuery);
   }
 
   // Add sorting to the query
-  let esbSearchQuery = esb
+  const esbSearchQuery = esb
     .requestBodySearch()
     .query(esbBoolQuery)
     .version(true);
@@ -138,15 +138,14 @@ export const getOpenSearchData = (
   dateFormat: string,
   timezone: string
 ) => {
-  let hits: any = [];
-  for (let valueRes of arrayHits) {
-    for (let data of valueRes.hits) {
+  const hits: any = [];
+  for (const valueRes of arrayHits) {
+    for (const data of valueRes.hits) {
       const fields = data.fields;
       // get all the fields of type date and format them to excel format
-      let tempKeyElement: string[] = [];
-      for (let dateField of report._source.dateFields) {
-        let keys;
-        keys = dateField.split('.');
+      const tempKeyElement: string[] = [];
+      for (const dateField of report._source.dateFields) {
+        const keys = dateField.split('.');
         const dateValue = data._source[dateField];
         const fieldDateValue = fields?.[dateField];
         const isDateFieldPresent = isKeyPresent(data._source, dateField);
@@ -172,14 +171,14 @@ export const getOpenSearchData = (
             }
             // else to cover cases with nested date fields
           } else {
-            let keyElement = keys.shift();
+            const keyElement = keys.shift();
             // if conditions to determine if the date field's value is an array or a string
             if (fieldDateValue && typeof fieldDateValue === 'string') {
               keys.push(
                 moment.utc(fieldDateValue).tz(timezone).format(dateFormat)
               );
             } else if (dateValue?.length !== 0 && dateValue instanceof Array) {
-              let tempArray: string[] = [];
+              const tempArray: string[] = [];
               fieldDateValue?.forEach((index) => {
                 tempArray.push(
                   moment.utc(index).tz(timezone).format(dateFormat)
@@ -190,7 +189,7 @@ export const getOpenSearchData = (
               keys.push([]);
             }
             const nestedJSON = arrayToNestedJSON(keys);
-            let keyLength = Object.keys(data._source);
+            const keyLength = Object.keys(data._source);
             // to check if the nested field have anyother keys apart from date field
             if (tempKeyElement.includes(keyElement) || keyLength.length > 1) {
               data._source[keyElement] = {
@@ -204,12 +203,12 @@ export const getOpenSearchData = (
           }
         }
       }
-      delete data['fields'];
+      delete data.fields;
       if (report._source.fields_exist === true) {
-        let result = traverse(data, report._source.selectedFields);
+        const result = traverse(data, report._source.selectedFields);
         hits.push(params.excel ? sanitize(result) : result);
       } else {
-        let result = flattenHits(data);
+        const result = flattenHits(data);
         hits.push(params.excel ? sanitize(result) : result);
       }
       // Truncate to expected limit size
@@ -222,16 +221,12 @@ export const getOpenSearchData = (
 };
 
 // Convert the data to Csv format
-export const convertToCSV = async (dataset, csvSeparator) => {
-  let convertedData: any = [];
+export const convertToCSV = (dataset, csvSeparator) => {
   const options = {
     delimiter: { field: csvSeparator, eol: '\n' },
     emptyFieldValue: ' ',
   };
-  await converter.json2csvAsync(dataset[0], options).then((csv) => {
-    convertedData = csv;
-  });
-  return convertedData;
+  return json2csv(dataset[0], options);
 };
 
 function flattenHits(
@@ -263,7 +258,9 @@ function flattenHits(
         }
 
         for (const [flatKey, flatVals] of Object.entries(grouped)) {
-          result[prefix.replace(/^_source\./, '') + flatKey] = flatVals.join(',');
+          result[prefix.replace(/^_source\./, '') + flatKey] = flatVals.join(
+            ','
+          );
         }
       } else {
         result[prefix.replace(/^_source\./, '') + key] = value.join(',');
@@ -281,7 +278,7 @@ function flattenObject(obj = {}, parentKey = '', result: any = {}) {
     const newKey = parentKey ? `${parentKey}.${key}` : key;
 
     if (
-      typeof value == 'object' &&
+      typeof value === 'object' &&
       value !== null &&
       !Array.isArray(value) &&
       Object.keys(value).length > 0
@@ -320,7 +317,7 @@ export const convertToExcel = async (dataset: any) => {
   );
 };
 
-//Return only the selected fields
+// Return only the selected fields
 function traverse(
   data: any,
   keys: string[],

--- a/yarn.lock
+++ b/yarn.lock
@@ -182,9 +182,9 @@
     "@types/tough-cookie" "*"
 
 "@types/node@*":
-  version "26.0.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-26.0.1.tgz#4a60e2c7a6d68bd261e265f8983bfe1601263ce3"
-  integrity sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==
+  version "26.1.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-26.1.0.tgz#aa85f0727fc5611347091c478341c63650903439"
+  integrity sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==
   dependencies:
     undici-types "~8.3.0"
 
@@ -772,10 +772,10 @@ decimal.js@^10.4.3:
   resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.6.0.tgz#e649a43e3ab953a72192ff5983865e509f37ed9a"
   integrity sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==
 
-deeks@2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/deeks/-/deeks-2.6.1.tgz#ee852ab76d5b4ca4bcfda34ba55660c40b92f505"
-  integrity sha512-PZrpz5xLo2JPZa3L+kqMMMdZU5pRwMysTM1xd6pLhNtgQw4Iq3wbF2QWaQTVh+HRq9Yg4rcjDIJ+scfGLxmsjQ==
+deeks@3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/deeks/-/deeks-3.2.1.tgz#b8a83dc949b1ee278dc8f5e72bddd03ac3565bcc"
+  integrity sha512-D/o0k3pCG1aI1cxb/dDiWmtMc4Rh7ZQBybXpfMsw9Rbtqwg8kUA9SpYkWcw0pAUjZSnPm8MluctiS0o68r69jQ==
 
 define-data-property@^1.1.4:
   version "1.1.4"
@@ -791,7 +791,7 @@ delayed-stream@~1.0.0:
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
-doc-path@3.1.0:
+doc-path@3.1.0, doc-path@4.1.4:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/doc-path/-/doc-path-3.1.0.tgz#4e1b5ba445d02e6b8f5bc122e8af43e659463d14"
   integrity sha512-Pv2hLQbUM8du5681lTWIYk0OtVBmNhMAeZNGeFhMMJBIR89Nw4XesBwee1Xtlfk83n71tn0Y6VsJOn4d3qIiTw==
@@ -1433,13 +1433,13 @@ jsesc@^3.0.2:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-3.1.0.tgz#74d335a234f67ed19907fdadfac7ccf9d409825d"
   integrity sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==
 
-json-2-csv@^3.20.0:
-  version "3.20.0"
-  resolved "https://registry.yarnpkg.com/json-2-csv/-/json-2-csv-3.20.0.tgz#8d9a7ad8a296016dbeb43eb76c03e66ac26d9136"
-  integrity sha512-IbqUB+yaycVNB/q2fiY5kyRjy5kRiEXqvNvGlxM5L0Bfi0RdvklVHc4t9MfeYF1GsZVpZWDBs9LdWmSjsQ8jvg==
+json-2-csv@^5.5.11:
+  version "5.5.11"
+  resolved "https://registry.yarnpkg.com/json-2-csv/-/json-2-csv-5.5.11.tgz#3ad21d2d6f665524f2e837d96ca9af9645c0998f"
+  integrity sha512-kVuwgVL7rfad9ETf02ZZxJPuMR5ZSUn139+T34BfmVxYhb/IsAIm/LzEeQ8YLJmXfuQ5z7LUAFrgPZZM6VLJPw==
   dependencies:
-    deeks "2.6.1"
-    doc-path "3.1.0"
+    deeks "3.2.1"
+    doc-path "4.1.4"
 
 json-schema@0.4.0:
   version "0.4.0"


### PR DESCRIPTION

### Description

json-2-csv  (CVE-2026-9673, GHSA-g27c-q7cp-mhx6, MEDIUM).

Upgrade from ^3.20.0 to ^5.5.11 and update the call site to use the v5 named export (json2csv) instead of the removed json2csvAsync.


### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
