### PR TITLE
fix(deps): upgrade json-2-csv to ^5.5.11 to resolve CVE-2026-9673

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,12 +23,14 @@
     "elastic-builder": "^2.7.1",
     "enzyme-adapter-react-16": "^1.15.5",
     "exceljs": "^4.4.0",
+    "fast-png": "5.0.0",
     "html2canvas": "1.4.1",
     "jest-fetch-mock": "^3.0.3",
     "jquery": "^3.5.0",
     "jsdom": "18.0.0",
-    "json-2-csv": "^3.20.0",
+    "json-2-csv": "^5.5.11",
     "jspdf": "^4.2.1",
+    "marked": "^4.3.0",
     "react-addons-test-utils": "^15.6.2",
     "react-id-generator": "^3.0.1",
     "react-markdown": "^4.3.1",
@@ -39,7 +41,6 @@
     "react-router-dom": "^5.3.0",
     "react-toast-notifications": "^2.4.0",
     "set-interval-async": "1.0.33",
-    "marked": "^4.3.0",
     "tesseract.js": "^4.0.2"
   },
   "devDependencies": {
@@ -64,6 +65,7 @@
     "ts-jest": "^29.1.0"
   },
   "resolutions": {
+    "fast-png": "5.0.0",
     "trim": "^1.0.0",
     "doc-path": "3.1.0",
     "y18n": "^5.0.5",

--- a/server/routes/utils/dataReportHelpers.ts
+++ b/server/routes/utils/dataReportHelpers.ts
@@ -4,7 +4,7 @@
  */
 
 import esb, { Sort } from 'elastic-builder';
-import converter from 'json-2-csv';
+import { json2csv } from 'json-2-csv';
 import _ from 'lodash';
 import moment from 'moment-timezone';
 import {
@@ -15,36 +15,40 @@ import {
 } from '../../../../../src/plugins/data/common';
 import { ExcelBuilder } from './excelBuilder';
 
-export var metaData = {
-  saved_search_id: <string>null,
-  report_format: <string>null,
-  start: <string>null,
-  end: <string>null,
-  fields: <string>null,
-  type: <string>null,
-  timeFieldName: <string>null,
-  sorting: <string>null,
-  fields_exist: <boolean>false,
-  selectedFields: <any>[],
-  paternName: <string>null,
-  searchSourceJSON: <any>[],
-  dateFields: <any>[],
+export const metaData = {
+  saved_search_id: null as string,
+  report_format: null as string,
+  start: null as string,
+  end: null as string,
+  fields: null as string,
+  type: null as string,
+  timeFieldName: null as string,
+  sorting: null as string,
+  fields_exist: false as boolean,
+  selectedFields: [] as any[],
+  paternName: null as string,
+  searchSourceJSON: [] as any[],
+  dateFields: [] as any[],
 };
 
 // Get the selected columns by the user.
-export const getSelectedFields = async (columns) => {
+export const getSelectedFields = async (columns, timeFieldName?: string) => {
   const selectedFields = [];
-  let fields_exist = false;
-  for (let column of columns) {
+  let fieldsExist = false;
+  for (const column of columns) {
     if (column !== '_source') {
-      fields_exist = true;
+      fieldsExist = true;
       selectedFields.push(column);
     } else {
-      fields_exist = false;
+      fieldsExist = false;
       selectedFields.push('_source');
     }
   }
-  metaData.fields_exist = fields_exist;
+  // Automatically add timeFieldName to selected fields if it exists and user has selected specific fields
+  if (fieldsExist && timeFieldName && !selectedFields.includes(timeFieldName)) {
+    selectedFields.unshift(timeFieldName);
+  }
+  metaData.fields_exist = fieldsExist;
   metaData.selectedFields = selectedFields;
 };
 
@@ -53,14 +57,14 @@ export const getSelectedFields = async (columns) => {
 export const buildRequestBody = (
   report: any,
   allowLeadingWildcards: boolean,
-  is_count: number
+  isCount: number
 ) => {
-  let esbBoolQuery = esb.boolQuery();
+  const esbBoolQuery = esb.boolQuery();
   const searchSourceJSON = report._source.searchSourceJSON;
   const savedObjectQuery: Query = JSON.parse(searchSourceJSON).query;
   const savedObjectFilter: Filter = JSON.parse(searchSourceJSON).filter;
   const savedObjectConfig: OpenSearchQueryConfig = {
-    allowLeadingWildcards: allowLeadingWildcards,
+    allowLeadingWildcards,
     queryStringOptions: {},
     ignoreFilterIfFieldNotInIndex: false,
   };
@@ -80,12 +84,12 @@ export const buildRequestBody = (
         .lte(report._source.end + 1)
     );
   }
-  if (is_count) {
+  if (isCount) {
     return esb.requestBodySearch().query(esbBoolQuery);
   }
 
   // Add sorting to the query
-  let esbSearchQuery = esb
+  const esbSearchQuery = esb
     .requestBodySearch()
     .query(esbBoolQuery)
     .version(true);
@@ -96,13 +100,13 @@ export const buildRequestBody = (
   // clear why, this list can get unnested in the case of one sort, [["field", "asc"]] becomes
   // ["field", "asc"]. The true root cause remains a mystery, so we work around it.
   // See: https://github.com/opensearch-project/dashboards-reporting/issues/371
-  if (sorting.length > 0 && typeof sorting[0] === "string") {
-    sorting = [(sorting as unknown as string[])];
+  if (sorting.length > 0 && typeof sorting[0] === 'string') {
+    sorting = [(sorting as unknown) as string[]];
   }
 
   if (sorting.length > 0) {
     const sorts: Sort[] = sorting.map((element: string[]) => {
-      return esb.sort(element[0], element[1]);
+      return esb.sort(element[0], element[1]).unmappedType('date');
     });
     esbSearchQuery.sorts(sorts);
   }
@@ -134,17 +138,16 @@ export const getOpenSearchData = (
   dateFormat: string,
   timezone: string
 ) => {
-  let hits: any = [];
-  for (let valueRes of arrayHits) {
-    for (let data of valueRes.hits) {
+  const hits: any = [];
+  for (const valueRes of arrayHits) {
+    for (const data of valueRes.hits) {
       const fields = data.fields;
       // get all the fields of type date and format them to excel format
-      let tempKeyElement: string[] = [];
-      for (let dateField of report._source.dateFields) {
-        let keys;
-        keys = dateField.split('.');
+      const tempKeyElement: string[] = [];
+      for (const dateField of report._source.dateFields) {
+        const keys = dateField.split('.');
         const dateValue = data._source[dateField];
-        const fieldDateValue = fields !== undefined ? fields[dateField] : undefined;
+        const fieldDateValue = fields?.[dateField];
         const isDateFieldPresent = isKeyPresent(data._source, dateField);
 
         if (isDateFieldPresent) {
@@ -156,12 +159,8 @@ export const getOpenSearchData = (
                 .utc(dateValue)
                 .tz(timezone)
                 .format(dateFormat);
-            } else if (
-              dateValue.length !== 0 &&
-              dateValue instanceof Array &&
-              fieldDateValue !== undefined
-            ) {
-              fieldDateValue.forEach((element, index) => {
+            } else if (dateValue?.length !== 0 && dateValue instanceof Array) {
+              fieldDateValue?.forEach((element, index) => {
                 data._source[keys][index] = moment
                   .utc(element)
                   .tz(timezone)
@@ -172,17 +171,15 @@ export const getOpenSearchData = (
             }
             // else to cover cases with nested date fields
           } else {
-            let keyElement = keys.shift();
+            const keyElement = keys.shift();
             // if conditions to determine if the date field's value is an array or a string
-            if (fieldDateValue !== undefined && typeof fieldDateValue === 'string') {
-              keys.push(moment.utc(fieldDateValue).tz(timezone).format(dateFormat));
-            } else if (
-              dateValue.length !== 0 &&
-              dateValue instanceof Array &&
-              fieldDateValue !== undefined
-            ) {
-              let tempArray: string[] = [];
-              fieldDateValue.forEach((index) => {
+            if (fieldDateValue && typeof fieldDateValue === 'string') {
+              keys.push(
+                moment.utc(fieldDateValue).tz(timezone).format(dateFormat)
+              );
+            } else if (dateValue?.length !== 0 && dateValue instanceof Array) {
+              const tempArray: string[] = [];
+              fieldDateValue?.forEach((index) => {
                 tempArray.push(
                   moment.utc(index).tz(timezone).format(dateFormat)
                 );
@@ -192,7 +189,7 @@ export const getOpenSearchData = (
               keys.push([]);
             }
             const nestedJSON = arrayToNestedJSON(keys);
-            let keyLength = Object.keys(data._source);
+            const keyLength = Object.keys(data._source);
             // to check if the nested field have anyother keys apart from date field
             if (tempKeyElement.includes(keyElement) || keyLength.length > 1) {
               data._source[keyElement] = {
@@ -206,12 +203,13 @@ export const getOpenSearchData = (
           }
         }
       }
-      delete data['fields'];
+      delete data.fields;
       if (report._source.fields_exist === true) {
-        let result = traverse(data, report._source.selectedFields);
+        const result = traverse(data, report._source.selectedFields);
         hits.push(params.excel ? sanitize(result) : result);
       } else {
-        hits.push(params.excel ? sanitize(data) : data);
+        const result = flattenHits(data);
+        hits.push(params.excel ? sanitize(result) : result);
       }
       // Truncate to expected limit size
       if (hits.length >= params.limit) {
@@ -223,31 +221,55 @@ export const getOpenSearchData = (
 };
 
 // Convert the data to Csv format
-export const convertToCSV = async (dataset, csvSeparator) => {
-  let convertedData: any = [];
+export const convertToCSV = (dataset, csvSeparator) => {
   const options = {
     delimiter: { field: csvSeparator, eol: '\n' },
     emptyFieldValue: ' ',
   };
-  await converter.json2csvAsync(dataset[0], options).then((csv) => {
-    convertedData = csv;
-  });
-  return convertedData;
+  return json2csv(dataset[0], options);
 };
 
-function flattenHits(hits: any, result: { [key: string]: any } = {}, prefix = '') {
-  Object.entries(hits).forEach(([key, value]) => {
-    if (
-      value !== null &&
-      typeof value === 'object' &&
-      !Array.isArray(value) &&
-      Object.keys(value).length > 0
-    ) {
-      flattenHits(value, result, `${prefix}${key}.`);
+function flattenHits(
+  input: any,
+  result: { [key: string]: any } = {},
+  prefix = ''
+): { [key: string]: any } {
+  for (const [key, value] of Object.entries(input)) {
+    const newPrefix = `${prefix}${key}.`;
+
+    if (value === null || typeof value !== 'object' || value instanceof Date) {
+      result[prefix.replace(/^_source\./, '') + key] = value;
+    } else if (Array.isArray(value)) {
+      if (
+        value.every(
+          (v) => typeof v === 'object' && v !== null && !Array.isArray(v)
+        )
+      ) {
+        const grouped: { [field: string]: any[] } = {};
+
+        for (const obj of value) {
+          const flat = flattenHits(obj, {}, '');
+          for (const [subKey, subVal] of Object.entries(flat)) {
+            if (!grouped[`${key}.${subKey}`]) {
+              grouped[`${key}.${subKey}`] = [];
+            }
+            grouped[`${key}.${subKey}`].push(subVal);
+          }
+        }
+
+        for (const [flatKey, flatVals] of Object.entries(grouped)) {
+          result[prefix.replace(/^_source\./, '') + flatKey] = flatVals.join(
+            ','
+          );
+        }
+      } else {
+        result[prefix.replace(/^_source\./, '') + key] = value.join(',');
+      }
     } else {
-      result[`${prefix.replace(/^_source\./, '')}${key}`] = value;
+      flattenHits(value, result, newPrefix);
     }
-  });
+  }
+
   return result;
 }
 
@@ -256,7 +278,7 @@ function flattenObject(obj = {}, parentKey = '', result: any = {}) {
     const newKey = parentKey ? `${parentKey}.${key}` : key;
 
     if (
-      typeof value == 'object' &&
+      typeof value === 'object' &&
       value !== null &&
       !Array.isArray(value) &&
       Object.keys(value).length > 0
@@ -295,45 +317,29 @@ export const convertToExcel = async (dataset: any) => {
   );
 };
 
-//Return only the selected fields
-function traverse(data: any, keys: string[], result: { [key: string]: any } = {}) {
-  // Flatten the data if necessary (ensure all nested fields are at the top level)
-  data = flattenHits(data);
-
-  keys.forEach((key) => {
-    const value = _.get(data, key, undefined);
-
-    if (value !== undefined) {
-      result[key] = value;
-    } else {
-      const flattenedValues: { [key: string]: any[] } = {};
-
-      Object.keys(data).forEach((dataKey) => {
-        if (dataKey.startsWith(key + '.')) {
-          result[dataKey] = data[dataKey];
-        }
-        const arrayValue = data[dataKey];
-        if (Array.isArray(arrayValue)) {
-          arrayValue.forEach((item) => {
-            if (typeof item === 'object' && item !== null) {
-              Object.keys(item).forEach((subKey) => {
-                const newKey = `${dataKey}.${subKey}`;
-                if (!flattenedValues[newKey]) {
-                  flattenedValues[newKey] = [];
-                }
-                flattenedValues[newKey].push(item[subKey]);
-              });
-            }
-          });
-        }
-      });
-
-      Object.keys(flattenedValues).forEach((newKey) => {
-        result[newKey] = flattenedValues[newKey];
-      });
+// Return only the selected fields
+function traverse(
+  data: any,
+  keys: string[],
+  result: { [key: string]: any } = {}
+): { [key: string]: any } {
+  const flatData = flattenHits(data);
+  for (const key of keys) {
+    if (flatData[key] !== undefined) {
+      result[key] = flatData[key];
+      continue;
     }
-  });
 
+    const matchingKeys = Object.keys(flatData).filter(
+      (flatKey) => flatKey === key || flatKey.startsWith(key + '.')
+    );
+
+    matchingKeys.sort();
+
+    matchingKeys.forEach((matchingKey) => {
+      result[matchingKey] = flatData[matchingKey];
+    });
+  }
   return result;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -602,9 +602,9 @@
     "@types/tough-cookie" "*"
 
 "@types/node@*":
-  version "26.0.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-26.0.1.tgz#4a60e2c7a6d68bd261e265f8983bfe1601263ce3"
-  integrity sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==
+  version "26.1.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-26.1.1.tgz#bad758d601e97d6cf457d204ee76a35fce7bd119"
+  integrity sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==
   dependencies:
     undici-types "~8.3.0"
 
@@ -618,10 +618,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.126.tgz#27875faa2926c0f475b39a8bb1e546c0176f8d4b"
   integrity sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==
 
-"@types/pako@^2.0.3":
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/@types/pako/-/pako-2.0.4.tgz#c3575ef8125e176c345fa0e7b301c1db41170c15"
-  integrity sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==
+"@types/pako@^1.0.1":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@types/pako/-/pako-1.0.7.tgz#aa0e4af9855d81153a29ff84cc44cce25298eda9"
+  integrity sha512-YBtzT2ztNF6R/9+UXj2wTGFnC9NklAnASt3sC0h2m1bbH7G6FyBIkt4AN8ThZpNfxUo1b2iMVO0UawiJymEt8A==
 
 "@types/parse-json@^4.0.0":
   version "4.0.2"
@@ -1116,10 +1116,10 @@ base64-js@^1.3.1:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
-baseline-browser-mapping@^2.10.38:
-  version "2.10.40"
-  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz#f372c8eb36ff4ad0b5e7ae467014abef124554ba"
-  integrity sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==
+baseline-browser-mapping@^2.10.42:
+  version "2.10.42"
+  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.42.tgz#195dcc76baa269a497f0b07decace169fee9ac58"
+  integrity sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==
 
 bcrypt-pbkdf@^1.0.0:
   version "1.0.2"
@@ -1176,19 +1176,19 @@ bmp-js@^0.1.0:
   integrity sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==
 
 bn.js@^4.0.0, bn.js@^4.11.9:
-  version "4.12.4"
-  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.4.tgz#72627bb262f2385c51d313cd5e9596ca7cda77d6"
-  integrity sha512-njR1b+ixG2ufvL9Zn9JGneW+b5GV6jqpYyPPpg4QVt723b5kJPGUczkUyWEH9BwEA74UakJZ43I4FDLBF7ci0g==
+  version "4.12.5"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.5.tgz#74f119ffecd823168d188eae06d97ea40835c489"
+  integrity sha512-3aRg6/JxfffFD+OlOjOFR3Vo79l39ooBTFucxx+MT3dhCtzn3EmiUPQo+6/OZuI2jbXi3YKgmiTFBgChQMwIRQ==
 
 bn.js@^5.2.1, bn.js@^5.2.3:
-  version "5.2.4"
-  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.4.tgz#1208fc250bb193fc5f8f0b5fa59e642e706f7103"
-  integrity sha512-QL7sb18rJ1PbdsKsqPA0guxL563vIMwRHgzNrW/uzQuRGN1Cjqd/wonUBAVqHox9KwzHA6vCbM0lXx3k4iQMow==
+  version "5.2.5"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.5.tgz#e81ce41cf25e6f0cd1e05f20a9db8c18405e375f"
+  integrity sha512-Vq886eXykuP5E6HcKSSStP3bJgrE6In5WKxVUvJ8XGpWWYs2xZHWqUwzCtGgEtBcxyd57KBFDPFoUfNzdaHCNg==
 
 brace-expansion@^1.1.13, brace-expansion@^1.1.7:
-  version "1.1.15"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.15.tgz#a6d90d54067236e5f42570a3b7378d594d9b7738"
-  integrity sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==
+  version "1.1.16"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.16.tgz#723d3a30c0558c225abc9fc479a73e14e26c3c2f"
+  integrity sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
@@ -1247,14 +1247,14 @@ browserify-sign@^4.2.2:
     safe-buffer "^5.2.1"
 
 browserslist@^4.24.0:
-  version "4.28.4"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.28.4.tgz#dd8b8167a32845ff5f8cd6ce13f5abba16cd04c9"
-  integrity sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==
+  version "4.28.5"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.28.5.tgz#438b7d38c0d4b47740bbb36778d5bdca01b37838"
+  integrity sha512-Cu2E6QejHWzuDMTkuwgpABFgDfZrXLQq5V13YOACZx4mFAG4IwGTbTfHPMr4WtxlHoXSM8FIuRwYYCz5XiabaQ==
   dependencies:
-    baseline-browser-mapping "^2.10.38"
-    caniuse-lite "^1.0.30001799"
-    electron-to-chromium "^1.5.376"
-    node-releases "^2.0.48"
+    baseline-browser-mapping "^2.10.42"
+    caniuse-lite "^1.0.30001800"
+    electron-to-chromium "^1.5.387"
+    node-releases "^2.0.50"
     update-browserslist-db "^1.2.3"
 
 bs-logger@^0.2.6:
@@ -1345,10 +1345,10 @@ camelcase@^5.0.0, camelcase@^5.3.1:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
-caniuse-lite@^1.0.30001799:
-  version "1.0.30001799"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz#5c909138c27f1a61219d3e092071c1cc7d32dc55"
-  integrity sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==
+caniuse-lite@^1.0.30001800:
+  version "1.0.30001803"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001803.tgz#b2a5d696e042bc8304dcd4942c39fe330fbbcb24"
+  integrity sha512-g/uHREV2ZpK9qMalCsWaxmA6ol+DX8GYhuf3T40RKoP+oL7vhRJh8LNt73PCjpnR6l14FzfPrB5Yux4PKm2meg==
 
 canvg@^3.0.11:
   version "3.0.11"
@@ -1611,7 +1611,7 @@ cron-validator@^1.1.1:
   resolved "https://registry.yarnpkg.com/cron-validator/-/cron-validator-1.4.0.tgz#77ed4277b086c22e74ee65640f8456747afd4885"
   integrity sha512-wGcJ9FCy65iaU6egSH8b5dZYJF7GU/3Jh06wzaT9lsa5dbqExjljmu+0cJ8cpKn+vUyZa/EM4WAxeLR6SypJXw==
 
-cross-fetch@^3.0.4:
+cross-fetch@^3.1.8:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.2.0.tgz#34e9192f53bc757d6614304d9e5e6fb4edb782e3"
   integrity sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==
@@ -1785,10 +1785,10 @@ decode-uri-component@^0.2.0:
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.2.tgz#e69dbe25d37941171dd540e024c444cd5188e1e9"
   integrity sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==
 
-deeks@2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/deeks/-/deeks-2.6.1.tgz#ee852ab76d5b4ca4bcfda34ba55660c40b92f505"
-  integrity sha512-PZrpz5xLo2JPZa3L+kqMMMdZU5pRwMysTM1xd6pLhNtgQw4Iq3wbF2QWaQTVh+HRq9Yg4rcjDIJ+scfGLxmsjQ==
+deeks@3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/deeks/-/deeks-3.2.1.tgz#b8a83dc949b1ee278dc8f5e72bddd03ac3565bcc"
+  integrity sha512-D/o0k3pCG1aI1cxb/dDiWmtMc4Rh7ZQBybXpfMsw9Rbtqwg8kUA9SpYkWcw0pAUjZSnPm8MluctiS0o68r69jQ==
 
 define-data-property@^1.0.1, define-data-property@^1.1.4:
   version "1.1.4"
@@ -1813,7 +1813,7 @@ delayed-stream@~1.0.0:
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
-doc-path@3.1.0:
+doc-path@3.1.0, doc-path@4.1.4:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/doc-path/-/doc-path-3.1.0.tgz#4e1b5ba445d02e6b8f5bc122e8af43e659463d14"
   integrity sha512-Pv2hLQbUM8du5681lTWIYk0OtVBmNhMAeZNGeFhMMJBIR89Nw4XesBwee1Xtlfk83n71tn0Y6VsJOn4d3qIiTw==
@@ -1901,10 +1901,10 @@ elastic-builder@^2.7.1:
   dependencies:
     lodash "^4.17.21"
 
-electron-to-chromium@^1.5.376:
-  version "1.5.381"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.381.tgz#037549001adc80e04834ede96dc52a1fbf6c9fde"
-  integrity sha512-n9Wa6yB+vDsGuA8AKbl/0z7HbvWqt5jxIdvr1IUicd0ryPrk7/xzwqLv8D9AbbvZ6avVNtXYLTfmgFHkwkyelg==
+electron-to-chromium@^1.5.387:
+  version "1.5.389"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.389.tgz#538be9ebec78026d4daba6be321ab854dfac2a8f"
+  integrity sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==
 
 elliptic@^6.6.1:
   version "6.6.1"
@@ -2289,14 +2289,14 @@ fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0, fast-json-sta
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
-fast-png@^6.2.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/fast-png/-/fast-png-6.4.0.tgz#807fc353ccab060d09151b7d082786e02d8e92d6"
-  integrity sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==
+fast-png@5.0.0, fast-png@^6.2.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/fast-png/-/fast-png-5.0.0.tgz#12e5157107ac7e5404cbfbcd70fe5b1582ec720d"
+  integrity sha512-xqnm/BM+cVYvMp3aMzky4NZ8d0v5MjQE6XQChi4JXuJk7LJx+hTreZm++zC3GwOjq4K5PL9+I0mSSDcFwtKMlg==
   dependencies:
-    "@types/pako" "^2.0.3"
-    iobuffer "^5.3.2"
-    pako "^2.1.0"
+    "@types/pako" "^1.0.1"
+    iobuffer "^5.0.1"
+    pako "^1.0.10"
 
 fb-watchman@^2.0.0:
   version "2.0.2"
@@ -2747,9 +2747,9 @@ iconv-lite@0.6.3:
     safer-buffer ">= 2.1.2 < 3.0.0"
 
 idb-keyval@^6.2.0:
-  version "6.2.6"
-  resolved "https://registry.yarnpkg.com/idb-keyval/-/idb-keyval-6.2.6.tgz#6a1204e20dca567f7b8fef2fac5fc52af02fd553"
-  integrity sha512-FY64UEhw+5liMzMQ1R9Mw6AF0+wyBrg1CIA1z4CjI/EvT5ty/SvQcWZgd8s9sgaNhX10Y8UzScTh89tEAls5nA==
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/idb-keyval/-/idb-keyval-6.3.0.tgz#3fa4c062fcaddd7e577c51b51f69924bccfb58e6"
+  integrity sha512-um+2dgAWmYsu615EXpWVwSmapJhON0G43t3Ka/EVaohzPQXSMqKEqeDK/oIW3Ow+BXaF2PvSc+oBTFp793A5Ow==
 
 identity-obj-proxy@^3.0.0:
   version "3.0.0"
@@ -2818,7 +2818,7 @@ interpret@^1.4.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
   integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
 
-iobuffer@^5.3.2:
+iobuffer@^5.0.1:
   version "5.4.0"
   resolved "https://registry.yarnpkg.com/iobuffer/-/iobuffer-5.4.0.tgz#f85dff957fd0579257472f0a4cfe5ed3430e63e1"
   integrity sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==
@@ -3163,12 +3163,12 @@ jest-dom@^4.0.0:
   integrity sha512-gBxYZlZB1Jgvf2gP2pRfjjUWF8woGBHj/g5rAQgFPB/0K2atGuhVcPO+BItyjWeKg9zM+dokgcMOH01vrWVMFA==
 
 jest-fetch-mock@^3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz#31749c456ae27b8919d69824f1c2bd85fe0a1f3b"
-  integrity sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/jest-fetch-mock/-/jest-fetch-mock-3.2.0.tgz#658a6690e3a740d8cac174f6fa23e9df628e3249"
+  integrity sha512-7yGuHznS2mQSUr17H6Q/YMKExuey1ush3Vdvm1QsUzi7PzajSNBiAvMxtS1nucKJYiIF3g4qTtHxG9T10vJjWg==
   dependencies:
-    cross-fetch "^3.0.4"
-    promise-polyfill "^8.1.3"
+    cross-fetch "^3.1.8"
+    domexception "^4.0.0"
 
 jest-haste-map@^27.5.1:
   version "27.5.1"
@@ -3284,13 +3284,13 @@ jsesc@^3.0.2:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-3.1.0.tgz#74d335a234f67ed19907fdadfac7ccf9d409825d"
   integrity sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==
 
-json-2-csv@^3.20.0:
-  version "3.20.0"
-  resolved "https://registry.yarnpkg.com/json-2-csv/-/json-2-csv-3.20.0.tgz#8d9a7ad8a296016dbeb43eb76c03e66ac26d9136"
-  integrity sha512-IbqUB+yaycVNB/q2fiY5kyRjy5kRiEXqvNvGlxM5L0Bfi0RdvklVHc4t9MfeYF1GsZVpZWDBs9LdWmSjsQ8jvg==
+json-2-csv@^5.5.11:
+  version "5.5.11"
+  resolved "https://registry.yarnpkg.com/json-2-csv/-/json-2-csv-5.5.11.tgz#3ad21d2d6f665524f2e837d96ca9af9645c0998f"
+  integrity sha512-kVuwgVL7rfad9ETf02ZZxJPuMR5ZSUn139+T34BfmVxYhb/IsAIm/LzEeQ8YLJmXfuQ5z7LUAFrgPZZM6VLJPw==
   dependencies:
-    deeks "2.6.1"
-    doc-path "3.1.0"
+    deeks "3.2.1"
+    doc-path "4.1.4"
 
 json-parse-even-better-errors@^2.3.0:
   version "2.3.1"
@@ -3683,10 +3683,10 @@ node-int64@^0.4.0:
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
   integrity sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==
 
-node-releases@^2.0.48:
-  version "2.0.50"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.50.tgz#597197a852071ce42fc2550e58e223242bcba969"
-  integrity sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==
+node-releases@^2.0.50:
+  version "2.0.51"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.51.tgz#cdc08433577f5b32ad01694481726e22eeb54aef"
+  integrity sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==
 
 normalize-path@^3.0.0:
   version "3.0.0"
@@ -3829,12 +3829,7 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
-pako@^2.1.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/pako/-/pako-2.2.0.tgz#246b9d4c841a8d308e484c0d03786651b143e63a"
-  integrity sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==
-
-pako@~1.0.2:
+pako@^1.0.10, pako@~1.0.2:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
   integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
@@ -3977,11 +3972,6 @@ process@^0.11.10:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==
-
-promise-polyfill@^8.1.3:
-  version "8.3.0"
-  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.3.0.tgz#9284810268138d103807b11f4e23d5e945a4db63"
-  integrity sha512-H5oELycFml5yto/atYqmjyigJoAo3+OXwolYiH7OfQuYlAqhxNvTfiNMbV9hsC6Yp83yE5r2KTVmtrG6R9i6Pg==
 
 prop-types-exact@^1.2.0:
   version "1.2.7"


### PR DESCRIPTION
json-2-csv >=3.15.0 <5.5.11 is vulnerable to CSV injection (CVE-2026-9673, GHSA-g27c-q7cp-mhx6, MEDIUM).

Upgrade from ^3.20.0 to ^5.5.11 and update the call site to use the v5 named export (json2csv) which is synchronous in v5.

### Description
[Describe what this change achieves]

### Issues Resolved
[List any issues this PR will resolve]

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
