### PR TITLE
Add SPDX license header checker and missing headers

### DIFF
--- a/.github/workflows/license-header-checker.yml
+++ b/.github/workflows/license-header-checker.yml
@@ -1,0 +1,12 @@
+---
+name: License Header Checker
+
+on: [push, pull_request]
+
+jobs:
+  license-header-checker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Add License Header
+        run: npx @kt3k/license-checker

--- a/.github/workflows/license-header-checker.yml
+++ b/.github/workflows/license-header-checker.yml
@@ -9,4 +9,4 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Add License Header
-        run: npx @kt3k/license-checker
+        run: npx @kt3k/license-checker@3.2.2

--- a/.licenserc.json
+++ b/.licenserc.json
@@ -1,0 +1,34 @@
+{
+  "**/*.*": [
+    " Copyright OpenSearch Contributors",
+    " SPDX-License-Identifier: Apache-2.0"
+  ],
+  "ignore": [
+    ".md",
+    ".json",
+    ".yml",
+    ".yaml",
+    ".txt",
+    ".html",
+    ".config",
+    ".png",
+    ".svg",
+    ".ico",
+    ".lock",
+    ".snap",
+    ".git",
+    ".gitignore",
+    ".whitesource",
+    ".lintstagedrc",
+    ".prettierignore",
+    ".prettierrc",
+    "node_modules/",
+    "build/",
+    "dist/",
+    "target/",
+    "**/__snapshots__/",
+    "*.d.ts",
+    "LICENSE",
+    "NOTICE"
+  ]
+}

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 const { defineConfig } = require('cypress');
 
 module.exports = defineConfig({

--- a/public/app.scss
+++ b/public/app.scss
@@ -1,0 +1,5 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+

--- a/server/routes/utils/excelBuilder.ts
+++ b/server/routes/utils/excelBuilder.ts
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import ExcelJS from 'exceljs';
 
 export class ExcelBuilder {

--- a/test/__mocks__/fileMock.js
+++ b/test/__mocks__/fileMock.js
@@ -1,1 +1,6 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 module.exports = 'react-mde-all';

--- a/test/__mocks__/styleMock.js
+++ b/test/__mocks__/styleMock.js
@@ -1,1 +1,6 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 module.exports = {};


### PR DESCRIPTION
### Description
Add SPDX license header validation to PR/push workflows using `@kt3k/license-checker`.

**Changes:**
  - Add `.github/workflows/license-header-checker.yml` 
  - Add `.licenserc.json` 
  - Add missing `SPDX-License-Identifier: Apache-2.0` headers to source files
  
### Related Issues
 [#6445](https://github.com/opensearch-project/opensearch-build/issues/6445)

### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
